### PR TITLE
changed UploadTranslationRequest.storageId type to number

### DIFF
--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -182,7 +182,7 @@ export namespace TranslationsModel {
     }
 
     export interface UploadTranslationRequest {
-        storageId: string;
+        storageId: number;
         fileId: number;
         importDuplicates?: boolean;
         importEqSuggestions?: boolean;

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -13,7 +13,7 @@ describe('Translations API', () => {
     const buildId = 1223;
     const statusId = 222;
     const url = 'test.com';
-    const storageId = '5';
+    const storageId = 5;
     const fileId = 51;
     const languageId = 'uk';
 


### PR DESCRIPTION
translationsApi.uploadTranslations was failing due to invalid type of storageId

Here is the error response: 
{"errors":[{"error":{"key":"storageId","errors":[{"code":"intTypeInvalid","message":"Invalid type given. Int expected"}]}}]}