### PR TITLE
add 'If-None-Match' eTag param to Translations.buildProjectFileTranslation

### DIFF
--- a/src/core/internal/axios/axiosProvider.ts
+++ b/src/core/internal/axios/axiosProvider.ts
@@ -43,9 +43,10 @@ export class AxisProvider {
                         return Promise.reject(error.response.data as CommonErrorResponse);
                     }
                 } else {
+                    const errorCode = (error.response && error.response.status) || '500';
                     const defaultError: CommonErrorResponse = {
                         error: {
-                            code: '500',
+                            code: errorCode,
                             message: `Request failed. ${error}`,
                         },
                     };

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -29,14 +29,20 @@ export class Translations extends CrowdinApi {
      * @param projectId project identifier
      * @param fileId file identifier
      * @param request request body
+     * @param eTag eTag 'If-None-Match' header
      */
     buildProjectFileTranslation(
         projectId: number,
         fileId: number,
         request: TranslationsModel.BuildProjectFileTranslationRequest,
-    ): Promise<ResponseObject<DownloadLink>> {
+        eTag?: string,
+    ): Promise<ResponseObject<TranslationsModel.BuildProjectFileTranslationResponse>> {
         const url = `${this.url}/projects/${projectId}/translations/builds/files/${fileId}`;
-        return this.post(url, request, this.defaultConfig());
+        const config = this.defaultConfig();
+        if (!!eTag) {
+            config.headers['If-None-Match'] = eTag;
+        }
+        return this.post(url, request, config);
     }
 
     /**
@@ -142,6 +148,10 @@ export namespace TranslationsModel {
         skipUntranslatedFiles?: boolean;
         exportApprovedOnly?: boolean;
         exportWithMinApprovalsCount?: number;
+    }
+
+    export interface BuildProjectFileTranslationResponse extends DownloadLink {
+        etag: string;
     }
 
     export interface PreTranslationStatusAttributes {


### PR DESCRIPTION
I was looking at using https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post, and noticed that there wasn't a way to set the etag header parameter, and that the etag property on the response was missing. 

A few things I wasn't certain about right away:

* When testing the change I got a 500 error back:
```
{ error:
   { code: '500',
     message: 'Request failed. Error: Request failed with status code 304' } }
```
The `error.response` was missing a data field so it was falling back to the `defaultError`. I made that propagate `error.response.status` as the `error.code` if it exists so it would return the right error, but I can revert / change that if you don't want that behavior
* I didn't see any instances of extending an interface in the codebase; happy to change that to explicitly list all fields instead of extending if preferred.