### PR TITLE
correct type for TranslationStatusModel.FileProgress.fileId (string->number)

### DIFF
--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -117,7 +117,7 @@ export namespace TranslationStatusModel {
     }
 
     export interface FileProgress {
-        fileId: string;
+        fileId: number;
         words: Words;
         phrases: Words;
         translationProgress: number;

--- a/tests/translationStatus/api.test.ts
+++ b/tests/translationStatus/api.test.ts
@@ -71,6 +71,7 @@ describe('Translation Status API', () => {
                             phrases: {
                                 total: phrasesCount,
                             },
+                            fileId: fileId,
                         },
                     },
                 ],
@@ -161,6 +162,7 @@ describe('Translation Status API', () => {
         const progress = await api.getLanguageProgress(projectId, languageId);
         expect(progress.data.length).toBe(1);
         expect(progress.data[0].data.phrases.total).toBe(phrasesCount);
+        expect(progress.data[0].data.fileId).toBe(fileId);
         expect(progress.pagination.limit).toBe(limit);
     });
 


### PR DESCRIPTION
The `fileId` returned in the response for `getLanguageProgress` is currently listed as a string, but the value you get from https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany is a number