### PR TITLE
fix(Users): correct return type in listProjectMembers

### DIFF
--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -188,7 +188,7 @@ export namespace UsersModel {
         fullName: string;
         role: Role;
         permissions: {
-            [key: string]: LanguageRole | string;
+            [lang: string]: LanguageRole | string;
         };
         avatarUrl: string;
         joinedAt: string;


### PR DESCRIPTION
This PR attempts to fix the return type of Users#listProjectMembers by separating the current type into two, one for regular Crowdin and the other one for Enterprise. This fix is not ideal however and I am open to suggestions on a way to make it possible to narrow the types down to either only enterprise or only regular Crowdin (possibly through the Crowdin constructor)