### PR TITLE
chore: drop support for node 10 and use latest node 16 features

### DIFF
--- a/ci/basic.yml
+++ b/ci/basic.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '^10.10.0'
+          versionSpec: '^12.22.10'
         displayName: 'Install Node.js'
       - script: npm install
         displayName: 'Install dependencies'
@@ -27,7 +27,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '^10.10.0'
+          versionSpec: '^12.22.10'
         displayName: 'Install Node.js'
       - script: npm install
         displayName: 'Install dependencies'
@@ -44,7 +44,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '^10.10.0'
+          versionSpec: '^12.22.10'
         displayName: 'Install Node.js'
       - script: npm install
         displayName: 'Install dependencies'

--- a/ci/templates/jobs.yml
+++ b/ci/templates/jobs.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       maxParallel: 4
       matrix:
+        node-16:
+          node_version: ^16.14.0
         node-14:
-          node_version: ^14.15.0
+          node_version: ^14.19.0
         node-12:
-          node_version: ^12.2.0
-        node-10:
-          node_version: ^10.10.0
+          node_version: ^12.22.10
     steps:
       - task: NodeTool@0
         inputs:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "dependencies": {
         "axios": "0.21.3"
     },
+    "engines": {
+        "node": ">=12.9.0"
+    },
     "lint-staged": {
         "*.js": [
             "eslint --fix",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -133,10 +133,10 @@ export abstract class CrowdinApi {
         this.token = credentials.token;
         this.organization = credentials.organization;
 
-        if (!!credentials.baseUrl) {
+        if (credentials.baseUrl) {
             this.url = credentials.baseUrl;
         } else {
-            if (!!this.organization) {
+            if (this.organization) {
                 this.url = `https://${this.organization}.${CrowdinApi.CROWDIN_URL_SUFFIX}`;
             } else {
                 this.url = `https://${CrowdinApi.CROWDIN_URL_SUFFIX}`;
@@ -144,7 +144,7 @@ export abstract class CrowdinApi {
         }
 
         let retryConfig: RetryConfig;
-        if (!!config && !!config.retryConfig) {
+        if (config?.retryConfig) {
             retryConfig = config.retryConfig;
         } else {
             retryConfig = {
@@ -159,7 +159,7 @@ export abstract class CrowdinApi {
     }
 
     protected addQueryParam(url: string, name: string, value?: any): string {
-        if (!!value) {
+        if (value) {
             url += new RegExp(/\?.+=.*/g).test(url) ? '&' : '?';
             url += `${name}=${value}`;
         }
@@ -172,31 +172,27 @@ export abstract class CrowdinApi {
                 Authorization: `Bearer ${this.token}`,
             },
         };
-        if (!!this.config) {
-            if (!!this.config.userAgent) {
-                config.headers['User-Agent'] = this.config.userAgent;
-            }
-            if (!!this.config.integrationUserAgent) {
-                config.headers['X-Crowdin-Integrations-User-Agent'] = this.config.integrationUserAgent;
-            }
+        if (this.config?.userAgent) {
+            config.headers['User-Agent'] = this.config.userAgent;
+        }
+        if (this.config?.integrationUserAgent) {
+            config.headers['X-Crowdin-Integrations-User-Agent'] = this.config.integrationUserAgent;
         }
         return config;
     }
 
     get httpClient(): HttpClient {
-        if (!!this.config) {
-            if (!!this.config.httpClient) {
-                return this.config.httpClient;
-            }
-            if (!!this.config.httpClientType) {
-                switch (this.config.httpClientType) {
-                    case HttpClientType.AXIOS:
-                        return CrowdinApi.AXIOS_INSTANCE;
-                    case HttpClientType.FETCH:
-                        return CrowdinApi.FETCH_INSTANCE;
-                    default:
-                        return CrowdinApi.AXIOS_INSTANCE;
-                }
+        if (this.config?.httpClient) {
+            return this.config.httpClient;
+        }
+        if (this.config?.httpClientType) {
+            switch (this.config.httpClientType) {
+                case HttpClientType.AXIOS:
+                    return CrowdinApi.AXIOS_INSTANCE;
+                case HttpClientType.FETCH:
+                    return CrowdinApi.FETCH_INSTANCE;
+                default:
+                    return CrowdinApi.AXIOS_INSTANCE;
             }
         }
         return CrowdinApi.AXIOS_INSTANCE;
@@ -215,7 +211,7 @@ export abstract class CrowdinApi {
         offset?: number,
         config?: { headers: any },
     ): Promise<ResponseList<T>> {
-        const conf = config || this.defaultConfig();
+        const conf = config ?? this.defaultConfig();
         if (this.fetchAllFlag) {
             this.fetchAllFlag = false;
             const maxAmount = this.maxLimit;
@@ -234,7 +230,7 @@ export abstract class CrowdinApi {
         maxAmount?: number,
     ): Promise<ResponseList<T>> {
         let limit = 500;
-        if (!!maxAmount && maxAmount < limit) {
+        if (maxAmount && maxAmount < limit) {
             limit = maxAmount;
         }
         let offset = 0;
@@ -249,15 +245,13 @@ export abstract class CrowdinApi {
                 resp.data = resp.data.concat(e.data);
                 resp.pagination.limit += e.data.length;
             }
-            if (e.data.length < limit || (!!maxAmount && resp.data.length >= maxAmount)) {
+            if (e.data.length < limit || (maxAmount && resp.data.length >= maxAmount)) {
                 break;
             } else {
                 offset += limit;
             }
-            if (!!maxAmount) {
-                if (maxAmount < resp.data.length + limit) {
-                    limit = maxAmount - resp.data.length;
-                }
+            if (maxAmount && maxAmount < resp.data.length + limit) {
+                limit = maxAmount - resp.data.length;
             }
         }
         return resp;

--- a/src/core/internal/axios/axiosProvider.ts
+++ b/src/core/internal/axios/axiosProvider.ts
@@ -36,14 +36,14 @@ export class AxisProvider {
             },
             error => {
                 this.pendingRequests = Math.max(0, this.pendingRequests - 1);
-                if (!!error.response && !!error.response.data) {
+                if (error.response?.data) {
                     if (error.response.status === 400) {
                         return Promise.reject(error.response.data as ValidationErrorResponse);
                     } else {
                         return Promise.reject(error.response.data as CommonErrorResponse);
                     }
                 } else {
-                    const errorCode = (error.response && error.response.status) || '500';
+                    const errorCode = error.response?.status ?? '500';
                     const defaultError: CommonErrorResponse = {
                         error: {
                             code: errorCode,

--- a/src/core/internal/fetch/fetchClient.ts
+++ b/src/core/internal/fetch/fetchClient.ts
@@ -28,11 +28,11 @@ export class FetchClient implements HttpClient {
 
     private async request(url: string, method: string, config?: RequestConfig, data?: any): Promise<any> {
         let body = undefined;
-        if (!!data) {
+        if (data) {
             if (typeof data === 'object' && !this.isBuffer(data)) {
                 body = JSON.stringify(data);
-                config = config || { headers: {} };
-                config.headers = config.headers || {};
+                config = config ?? { headers: {} };
+                config.headers = config.headers ?? {};
                 config.headers['Content-Type'] = 'application/json';
             } else {
                 body = data;
@@ -42,8 +42,8 @@ export class FetchClient implements HttpClient {
 
         return fetch(url, {
             method: method,
-            headers: !!config ? config.headers : {},
-            mode: (config && config.mode) || 'no-cors',
+            headers: config ? config.headers : {},
+            mode: config?.mode ?? 'no-cors',
             body: body,
         })
             .then(async (resp: any) => {

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -54,7 +54,7 @@ export class Translations extends CrowdinApi {
     ): Promise<ResponseObject<TranslationsModel.BuildProjectFileTranslationResponse>> {
         const url = `${this.url}/projects/${projectId}/translations/builds/files/${fileId}`;
         const config = this.defaultConfig();
-        if (!!eTag) {
+        if (eTag) {
             config.headers['If-None-Match'] = eTag;
         }
         return this.post(url, request, config);

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -933,7 +933,7 @@ export class UploadStorage extends CrowdinApi {
         const url = `${this.url}/storages`;
         const config = this.defaultConfig();
         config.headers['Crowdin-API-FileName'] = fileName;
-        if (!!contentType) {
+        if (contentType) {
             config.headers['Content-Type'] = contentType;
         } else {
             const fileNameParts = fileName.split('.');
@@ -942,7 +942,7 @@ export class UploadStorage extends CrowdinApi {
                 const fileExtrension = fileNameParts[fileNameParts.length - 1];
                 contentType = mimetypes[fileExtrension];
             }
-            config.headers['Content-Type'] = contentType || 'application/octet-stream';
+            config.headers['Content-Type'] = contentType ?? 'application/octet-stream';
         }
         return this.post(url, request, config);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
     "compilerOptions": {
         "module": "commonjs",
         "declaration": true,
-        "target": "es6",
+        "target": "es2019",
         "outDir": "./out",
         "lib": [
-            "es6"
+            "es2021"
         ],
         "strict": true
     },


### PR DESCRIPTION
This PR updates CI to run on node versions 12, 14 and 16 (all the ones supported by node) and refactors some code to use the latest features from es2021. This doesn't need a release, it's a simple QOL update