### PR TITLE
docs: add API links to all methods

### DIFF
--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -4,6 +4,7 @@ export class Dictionaries extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param languageIds filter progress by Language Identifiers
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.dictionaries.getMany
      */
     listDictionaries(projectId: number, languageIds?: string): Promise<ResponseList<DictionariesModel.Dictionary>> {
         let url = `${this.url}/projects/${projectId}/dictionaries`;
@@ -15,6 +16,7 @@ export class Dictionaries extends CrowdinApi {
      * @param projectId project identifier
      * @param languageId language identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.dictionaries.patch
      */
     editDictionary(
         projectId: number,

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -5,6 +5,7 @@ export class Distributions extends CrowdinApi {
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.getMany
      */
     listDistributions(
         projectId: number,
@@ -18,6 +19,7 @@ export class Distributions extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.post
      */
     createDistribution(
         projectId: number,
@@ -30,6 +32,7 @@ export class Distributions extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param hash hash
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.get
      */
     getDistribution(projectId: number, hash: string): Promise<ResponseObject<DistributionsModel.Distribution>> {
         const url = `${this.url}/projects/${projectId}/distributions/${hash}`;
@@ -39,6 +42,7 @@ export class Distributions extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param hash hash
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.delete
      */
     deleteDistribution(projectId: number, hash: string): Promise<void> {
         const url = `${this.url}/projects/${projectId}/distributions/${hash}`;
@@ -49,6 +53,7 @@ export class Distributions extends CrowdinApi {
      * @param projectId project identifier
      * @param hash hash
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.patch
      */
     editDistribution(
         projectId: number,
@@ -62,6 +67,7 @@ export class Distributions extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param hash hash
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.release.get
      */
     getDistributionRelease(
         projectId: number,
@@ -75,6 +81,7 @@ export class Distributions extends CrowdinApi {
      * @param projectId project identifier
      * @param hash hash
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.release.post
      */
     createDistributionRelease(
         projectId: number,

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -5,6 +5,7 @@ export class Glossaries extends CrowdinApi {
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.getMany
      */
     listGlossaries(groupId?: number, limit?: number, offset?: number): Promise<ResponseList<GlossariesModel.Glossary>> {
         let url = `${this.url}/glossaries`;
@@ -14,6 +15,7 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.post
      */
     addGlossary(request: GlossariesModel.CreateGlossaryRequest): Promise<ResponseObject<GlossariesModel.Glossary>> {
         const url = `${this.url}/glossaries`;
@@ -22,6 +24,7 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param glossaryId glossary identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.get
      */
     getGlossary(glossaryId: number): Promise<ResponseObject<GlossariesModel.Glossary>> {
         const url = `${this.url}/glossaries/${glossaryId}`;
@@ -30,6 +33,7 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param glossaryId glossary identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.delete
      */
     deleteGlossary(glossaryId: number): Promise<void> {
         const url = `${this.url}/glossaries/${glossaryId}`;
@@ -39,6 +43,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.patch
      */
     editGlossary(glossaryId: number, request: PatchRequest[]): Promise<ResponseObject<GlossariesModel.Glossary>> {
         const url = `${this.url}/glossaries/${glossaryId}`;
@@ -48,6 +53,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.exports.post
      */
     exportGlossary(
         glossaryId: number,
@@ -60,15 +66,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param exportId export identifier
-     */
-    downloadGlossary(glossaryId: number, exportId: string): Promise<ResponseObject<DownloadLink>> {
-        const url = `${this.url}/glossaries/${glossaryId}/exports/${exportId}/download`;
-        return this.get(url, this.defaultConfig());
-    }
-
-    /**
-     * @param glossaryId glossary identifier
-     * @param exportId export identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.exports.get
      */
     checkGlossaryExportStatus(
         glossaryId: number,
@@ -80,7 +78,18 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param glossaryId glossary identifier
+     * @param exportId export identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.exports.download.download
+     */
+    downloadGlossary(glossaryId: number, exportId: string): Promise<ResponseObject<DownloadLink>> {
+        const url = `${this.url}/glossaries/${glossaryId}/exports/${exportId}/download`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
+     * @param glossaryId glossary identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.imports.post
      */
     importGlossaryFile(
         glossaryId: number,
@@ -93,6 +102,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param importId import identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.imports.get
      */
     checkGlossaryImportStatus(
         glossaryId: number,
@@ -102,11 +112,15 @@ export class Glossaries extends CrowdinApi {
         return this.get(url, this.defaultConfig());
     }
 
+    /**
+     * @param glossaryId glossary identifier
+     * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
+     */
     listTerms(
         glossaryId: number,
         request: GlossariesModel.ListTermsRequest,
     ): Promise<ResponseList<GlossariesModel.Term>>;
-
     /**
      * @param glossaryId glossary identifier
      * @param userId list user glossaries
@@ -114,6 +128,7 @@ export class Glossaries extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param languageId term language identifier
      * @param translationOfTermId filter terms by termId
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
      */
     listTerms(
         glossaryId: number,
@@ -123,7 +138,6 @@ export class Glossaries extends CrowdinApi {
         languageId?: string,
         translationOfTermId?: number,
     ): Promise<ResponseList<GlossariesModel.Term>>;
-
     listTerms(
         glossaryId: number,
         userIdOrRequest?: number | GlossariesModel.ListTermsRequest,
@@ -148,6 +162,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.post
      */
     addTerm(
         glossaryId: number,
@@ -161,6 +176,7 @@ export class Glossaries extends CrowdinApi {
      * @param glossaryId glossary identifier
      * @param languageId languageId identifier
      * @param translationOfTermId term translation identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.deleteMany
      */
     clearGlossary(
         glossaryId: number,
@@ -176,6 +192,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param termId term identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.get
      */
     getTerm(glossaryId: number, termId: number): Promise<ResponseObject<GlossariesModel.Term>> {
         const url = `${this.url}/glossaries/${glossaryId}/terms/${termId}`;
@@ -185,6 +202,7 @@ export class Glossaries extends CrowdinApi {
     /**
      * @param glossaryId glossary identifier
      * @param termId term identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.delete
      */
     deleteTerm(glossaryId: number, termId: number): Promise<void> {
         const url = `${this.url}/glossaries/${glossaryId}/terms/${termId}`;
@@ -195,6 +213,7 @@ export class Glossaries extends CrowdinApi {
      * @param glossaryId glossary identifier
      * @param termId term identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.patch
      */
     editTerm(
         glossaryId: number,

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -10,6 +10,7 @@ export class Issues extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param type defines the issue type
      * @param status defines the issue resolution status
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.issues.getMany
      */
     listReportedIssues(
         projectId: number,
@@ -28,6 +29,7 @@ export class Issues extends CrowdinApi {
      * @param projectId project identifier
      * @param issueId issue identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.issues.patch
      */
     editIssue(projectId: number, issueId: number, request: PatchRequest[]): Promise<ResponseObject<IssuesModel.Issue>> {
         const url = `${this.url}/projects/${projectId}/issues/${issueId}`;

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -6,6 +6,7 @@ export class Labels extends CrowdinApi {
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.getMany
      */
     listLabels(projectId: number, limit?: number, offset?: number): Promise<ResponseList<LabelsModel.Label>> {
         const url = `${this.url}/projects/${projectId}/labels`;
@@ -15,6 +16,7 @@ export class Labels extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.post
      */
     addLabel(projectId: number, request: LabelsModel.AddLabelRequest): Promise<ResponseObject<LabelsModel.Label>> {
         const url = `${this.url}/projects/${projectId}/labels`;
@@ -24,6 +26,7 @@ export class Labels extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param labelId label identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.get
      */
     getLabel(projectId: number, labelId: number): Promise<ResponseObject<LabelsModel.Label>> {
         const url = `${this.url}/projects/${projectId}/labels/${labelId}`;
@@ -33,6 +36,7 @@ export class Labels extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param labelId label identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.delete
      */
     deleteLabel(projectId: number, labelId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/labels/${labelId}`;
@@ -43,6 +47,7 @@ export class Labels extends CrowdinApi {
      * @param projectId project identifier
      * @param labelId label identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.patch
      */
     editLabel(projectId: number, labelId: number, request: PatchRequest[]): Promise<ResponseObject<LabelsModel.Label>> {
         const url = `${this.url}/projects/${projectId}/labels/${labelId}`;
@@ -53,6 +58,7 @@ export class Labels extends CrowdinApi {
      * @param projectId project identifier
      * @param labelId label identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.strings.post
      */
     assignLabelToString(
         projectId: number,
@@ -67,6 +73,7 @@ export class Labels extends CrowdinApi {
      * @param projectId project identifier
      * @param labelId label identifier
      * @param stringIds string identifiers
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.strings.deleteMany
      */
     unassignLabelFromString(
         projectId: number,

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -4,6 +4,7 @@ export class Languages extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.getMany
      */
     listSupportedLanguages(limit?: number, offset?: number): Promise<ResponseList<LanguagesModel.Language>> {
         const url = `${this.url}/languages`;
@@ -12,6 +13,7 @@ export class Languages extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.post
      */
     addCustomLanguage(request: LanguagesModel.AddLanguageRequest): Promise<ResponseObject<LanguagesModel.Language>> {
         const url = `${this.url}/languages`;
@@ -20,6 +22,7 @@ export class Languages extends CrowdinApi {
 
     /**
      * @param languageId language identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.get
      */
     getLanguage(languageId: string): Promise<ResponseObject<LanguagesModel.Language>> {
         const url = `${this.url}/languages/${languageId}`;
@@ -28,6 +31,7 @@ export class Languages extends CrowdinApi {
 
     /**
      * @param languageId language identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.delete
      */
     deleteCustomLanguage(languageId: string): Promise<void> {
         const url = `${this.url}/languages/${languageId}`;
@@ -37,6 +41,7 @@ export class Languages extends CrowdinApi {
     /**
      * @param languageId language identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.patch
      */
     editCustomLanguage(languageId: string, request: PatchRequest[]): Promise<ResponseObject<LanguagesModel.Language>> {
         const url = `${this.url}/languages/${languageId}`;

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -5,6 +5,7 @@ export class MachineTranslation extends CrowdinApi {
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.mts.getMany
      */
     listMts(
         groupId?: number,
@@ -18,6 +19,7 @@ export class MachineTranslation extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.mts.post
      */
     createMt(
         request: MachineTranslationModel.CreateMachineTranslationRequest,
@@ -28,6 +30,7 @@ export class MachineTranslation extends CrowdinApi {
 
     /**
      * @param mtId mt identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.mts.getMany
      */
     getMt(mtId: number): Promise<ResponseObject<MachineTranslationModel.MachineTranslation>> {
         const url = `${this.url}/mts/${mtId}`;
@@ -36,6 +39,7 @@ export class MachineTranslation extends CrowdinApi {
 
     /**
      * @param mtId mt identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.mts.delete
      */
     deleteMt(mtId: number): Promise<void> {
         const url = `${this.url}/mts/${mtId}`;
@@ -45,6 +49,7 @@ export class MachineTranslation extends CrowdinApi {
     /**
      * @param mtId mt identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.mts.patch
      */
     updateMt(
         mtId: number,
@@ -58,6 +63,7 @@ export class MachineTranslation extends CrowdinApi {
      *
      * @param mtId mt identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.mts.translations.post
      */
     translate(
         mtId: number,

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -7,6 +7,7 @@ export class ProjectsGroups extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param userId get user own projects
      * @param limit maximum number of items to retrieve (default 25)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.getMany
      */
     listGroups(
         parentId?: number,
@@ -22,6 +23,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.post
      */
     addGroup(request: ProjectsGroupsModel.AddGroupRequest): Promise<ResponseObject<ProjectsGroupsModel.Group>> {
         const url = `${this.url}/groups`;
@@ -30,6 +32,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param group group identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.get
      */
     getGroup(groupId: number): Promise<ResponseObject<ProjectsGroupsModel.Group>> {
         const url = `${this.url}/groups/${groupId}`;
@@ -38,6 +41,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param groupId group identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.delete
      */
     deleteGroup(groupId: number): Promise<void> {
         const url = `${this.url}/groups/${groupId}`;
@@ -47,6 +51,7 @@ export class ProjectsGroups extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.patch
      */
     editGroup(groupId: number, request: PatchRequest[]): Promise<ResponseObject<ProjectsGroupsModel.Group>> {
         const url = `${this.url}/groups/${groupId}`;
@@ -58,6 +63,7 @@ export class ProjectsGroups extends CrowdinApi {
      * @param hasManagerAccess projects with manager access (default 0)
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.getMany
      */
     listProjects(
         groupId?: number,
@@ -73,6 +79,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.post
      */
     addProject(
         request:
@@ -86,6 +93,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.get
      */
     getProject(
         projectId: number,
@@ -96,6 +104,7 @@ export class ProjectsGroups extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.delete
      */
     deleteProject(projectId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}`;
@@ -105,6 +114,7 @@ export class ProjectsGroups extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.patch
      */
     editProject(
         projectId: number,

--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -4,6 +4,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.reports.post
      */
     generateGroupReport(
         groupId: number,
@@ -16,6 +17,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param reportId report identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.reports.get
      */
     checkGroupReportStatus(
         groupId: number,
@@ -28,6 +30,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param reportId report identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.reports.download.download
      */
     downloadGroupReport(groupId: number, reportId: string): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/groups/${groupId}/reports/${reportId}/download`;
@@ -36,6 +39,7 @@ export class Reports extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.reports.post
      */
     generateOrganizationReport(
         request: ReportsModel.GenerateGroupReportRequest,
@@ -46,6 +50,7 @@ export class Reports extends CrowdinApi {
 
     /**
      * @param reportId report identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.reports.get
      */
     checkOrganizationReportStatus(
         reportId: string,
@@ -56,6 +61,7 @@ export class Reports extends CrowdinApi {
 
     /**
      * @param reportId report identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.reports.download.download
      */
     downloadOrganizationReport(reportId: string): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/reports/${reportId}/download`;
@@ -65,6 +71,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.reports.post
      */
     generateReport(
         projectId: number,
@@ -77,6 +84,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param reportId report identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.reports.get
      */
     checkReportStatus(
         projectId: number,
@@ -89,6 +97,7 @@ export class Reports extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param reportId report identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.reports.download.download
      */
     downloadReport(projectId: number, reportId: string): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/projects/${projectId}/reports/${reportId}/download`;

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -5,6 +5,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.getMany
      */
     listScreenshots(
         projectId: number,
@@ -18,6 +19,7 @@ export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.post
      */
     addScreenshot(
         projectId: number,
@@ -30,6 +32,7 @@ export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.get
      */
     getScreenshot(projectId: number, screenshotId: number): Promise<ResponseObject<ScreenshotsModel.Screenshot>> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}`;
@@ -40,6 +43,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.put
      */
     updateScreenshot(
         projectId: number,
@@ -53,6 +57,7 @@ export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.delete
      */
     deleteScreenshot(projectId: number, screenshotId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}`;
@@ -63,6 +68,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.patch
      */
     editScreenshot(
         projectId: number,
@@ -78,6 +84,7 @@ export class Screenshots extends CrowdinApi {
      * @param screenshotId screenshot identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.getMany
      */
     listScreenshotTags(
         projectId: number,
@@ -93,6 +100,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.putMany
      */
     replaceTags(projectId: number, screenshotId: number, request: ScreenshotsModel.AddTagRequest[]): Promise<void> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;
@@ -103,6 +111,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.post
      */
     addTag(
         projectId: number,
@@ -116,6 +125,7 @@ export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.deleteMany
      */
     clearTags(projectId: number, screenshotId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;
@@ -126,6 +136,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param tagId tag identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.get
      */
     getTag(projectId: number, screenshotId: number, tagId: number): Promise<ResponseObject<ScreenshotsModel.Tag>> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags/${tagId}`;
@@ -136,6 +147,7 @@ export class Screenshots extends CrowdinApi {
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
      * @param tagId tag identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.delete
      */
     deleteTag(projectId: number, screenshotId: number, tagId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags/${tagId}`;
@@ -147,6 +159,7 @@ export class Screenshots extends CrowdinApi {
      * @param screenshotId screenshot identifier
      * @param tagId tag identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.patch
      */
     updateTag(
         projectId: number,

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -6,6 +6,7 @@ export class SourceFiles extends CrowdinApi {
      * @param name filter branch by name
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.getMany
      */
     listProjectBranches(
         projectId: number,
@@ -21,6 +22,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.post
      */
     createBranch(
         projectId: number,
@@ -33,6 +35,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param branchId branch identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.get
      */
     getBranch(projectId: number, branchId: number): Promise<ResponseObject<SourceFilesModel.Branch>> {
         const url = `${this.url}/projects/${projectId}/branches/${branchId}`;
@@ -42,6 +45,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param branchId branch identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.delete
      */
     deleteBranch(projectId: number, branchId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/branches/${branchId}`;
@@ -52,6 +56,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param branchId branch identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.patch
      */
     editBranch(
         projectId: number,
@@ -70,6 +75,7 @@ export class SourceFiles extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param filter use to filter directories by name
      * @param recursion use to list directories recursively (works only when directoryId or branchId parameter is specified)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.getMany
      */
     listProjectDirectories(
         projectId: number,
@@ -107,6 +113,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.post
      */
     createDirectory(
         projectId: number,
@@ -119,6 +126,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param directoryId directory identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.get
      */
     getDirectory(projectId: number, directoryId: number): Promise<ResponseObject<SourceFilesModel.Directory>> {
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}`;
@@ -128,6 +136,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param directoryId directory identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.delete
      */
     deleteDirectory(projectId: number, directoryId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}`;
@@ -138,6 +147,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param directoryId directory identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.patch
      */
     editDirectory(
         projectId: number,
@@ -148,11 +158,6 @@ export class SourceFiles extends CrowdinApi {
         return this.patch(url, request, this.defaultConfig());
     }
 
-    listProjectFiles(
-        projectId: number,
-        request: SourceFilesModel.ListProjectFilesRequest,
-    ): Promise<ResponseList<SourceFilesModel.File>>;
-
     /**
      *
      * @param projectId project identifier
@@ -162,6 +167,7 @@ export class SourceFiles extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param recursion use to list files recursively
      * @param filter use to filter files by name
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany
      */
     listProjectFiles(
         projectId: number,
@@ -171,6 +177,11 @@ export class SourceFiles extends CrowdinApi {
         offset?: number,
         recursion?: any,
         filter?: string,
+    ): Promise<ResponseList<SourceFilesModel.File>>;
+
+    listProjectFiles(
+        projectId: number,
+        request: SourceFilesModel.ListProjectFilesRequest,
     ): Promise<ResponseList<SourceFilesModel.File>>;
 
     listProjectFiles(
@@ -199,6 +210,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.post
      */
     createFile(
         projectId: number,
@@ -211,6 +223,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param fileId file identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.get
      */
     getFile(projectId: number, fileId: number): Promise<ResponseObject<SourceFilesModel.File>> {
         const url = `${this.url}/projects/${projectId}/files/${fileId}`;
@@ -221,6 +234,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param fileId file identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.put
      */
     updateOrRestoreFile(
         projectId: number,
@@ -234,6 +248,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param fileId file identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.delete
      */
     deleteFile(projectId: number, fileId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/files/${fileId}`;
@@ -244,6 +259,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param fileId file identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.patch
      */
     editFile(
         projectId: number,
@@ -257,6 +273,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param fileId file identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.download.get
      */
     downloadFile(projectId: number, fileId: number): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/projects/${projectId}/files/${fileId}/download`;
@@ -268,6 +285,7 @@ export class SourceFiles extends CrowdinApi {
      * @param fileId file identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.revisions.getMany
      */
     listFileRevisions(
         projectId: number,
@@ -283,6 +301,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param fileId file identifier
      * @param revisionId revision identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.revisions.get
      */
     getFileRevision(
         projectId: number,
@@ -298,6 +317,7 @@ export class SourceFiles extends CrowdinApi {
      * @param branchId filter builds by branchId
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.getMany
      */
     listReviewedSourceFilesBuild(
         projectId: number,
@@ -313,6 +333,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.post
      */
     buildReviewedSourceFiles(
         projectId: number,
@@ -325,6 +346,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param buildId build identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.get
      */
     checkReviewedSourceFilesBuildStatus(
         projectId: number,
@@ -337,6 +359,7 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param buildId build identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.download.download
      */
     downloadReviewedSourceFiles(projectId: number, buildId: number): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/projects/${projectId}/strings/reviewed-builds/${buildId}/download`;

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -1,11 +1,6 @@
 import { BooleanInt, CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class SourceStrings extends CrowdinApi {
-    listProjectStrings(
-        projectId: number,
-        request: SourceStringsModel.ListProjectStringsRequest,
-    ): Promise<ResponseList<SourceStringsModel.String>>;
-
     /**
      * @param projectId project identifier
      * @param fileId file identifier
@@ -18,6 +13,7 @@ export class SourceStrings extends CrowdinApi {
      * @param croql filter strings by CroQL (Can't be used with `labelIds`, `filter` or `scope` in same request)
      * @param branchId filter by branch identifier
      * @param directoryId filter by directory identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.getMany
      */
     listProjectStrings(
         projectId: number,
@@ -31,6 +27,11 @@ export class SourceStrings extends CrowdinApi {
         croql?: string,
         branchId?: number,
         directoryId?: number,
+    ): Promise<ResponseList<SourceStringsModel.String>>;
+
+    listProjectStrings(
+        projectId: number,
+        request: SourceStringsModel.ListProjectStringsRequest,
     ): Promise<ResponseList<SourceStringsModel.String>>;
 
     listProjectStrings(
@@ -78,6 +79,7 @@ export class SourceStrings extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.post
      */
     addString(
         projectId: number,
@@ -90,6 +92,7 @@ export class SourceStrings extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param stringId string identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.get
      */
     getString(projectId: number, stringId: number): Promise<ResponseObject<SourceStringsModel.String>> {
         const url = `${this.url}/projects/${projectId}/strings/${stringId}`;
@@ -99,6 +102,7 @@ export class SourceStrings extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param stringId string identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.delete
      */
     deleteString(projectId: number, stringId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/strings/${stringId}`;
@@ -109,6 +113,7 @@ export class SourceStrings extends CrowdinApi {
      * @param projectId project identifier
      * @param stringId string identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.patch
      */
     editString(
         projectId: number,

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -1,11 +1,6 @@
 import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class StringComments extends CrowdinApi {
-    listStringComments(
-        projectId: number,
-        request?: StringCommentsModel.ListStringCommentsRequest,
-    ): Promise<ResponseList<StringCommentsModel.StringComment>>;
-
     /**
      * @param projectId project identifier
      * @param stringId string identifier
@@ -13,6 +8,7 @@ export class StringComments extends CrowdinApi {
      * @param targetLanguageId defines target language id. It can be one target language id or a list of comma-separated ones
      * @param issueType defines issue type. It can be one issue type or a list of comma-separated ones
      * @param issueStatus defines issue resolution status
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.getMany
      */
     listStringComments(
         projectId: number,
@@ -21,6 +17,11 @@ export class StringComments extends CrowdinApi {
         targetLanguageId?: string,
         issueType?: StringCommentsModel.IssueType,
         issueStatus?: StringCommentsModel.IssueStatus,
+    ): Promise<ResponseList<StringCommentsModel.StringComment>>;
+
+    listStringComments(
+        projectId: number,
+        request?: StringCommentsModel.ListStringCommentsRequest,
     ): Promise<ResponseList<StringCommentsModel.StringComment>>;
 
     listStringComments(
@@ -49,6 +50,7 @@ export class StringComments extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.post
      */
     addStringComment(
         projectId: number,
@@ -61,6 +63,7 @@ export class StringComments extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param stringCommentId string comment identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.get
      */
     getStringComment(
         projectId: number,
@@ -73,6 +76,7 @@ export class StringComments extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param stringCommentId string comment identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.delete
      */
     deleteStringComment(projectId: number, stringCommentId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/comments/${stringCommentId}`;
@@ -83,6 +87,7 @@ export class StringComments extends CrowdinApi {
      * @param projectId project identifier
      * @param stringCommentId string comment identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.patch
      */
     editStringComment(
         projectId: number,

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -9,6 +9,7 @@ export class StringTranslations extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param fileId file identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.getMany
      */
     listTranslationApprovals(
         projectId: number,
@@ -46,6 +47,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.post
      */
     addApproval(
         projectId: number,
@@ -58,6 +60,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param approvalId approval identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.get
      */
     approvalInfo(projectId: number, approvalId: number): Promise<ResponseObject<StringTranslationsModel.Approval>> {
         const url = `${this.url}/projects/${projectId}/approvals/${approvalId}`;
@@ -67,6 +70,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param approvalId approval identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.delete
      */
     removeApproval(projectId: number, approvalId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/approvals/${approvalId}`;
@@ -83,6 +87,7 @@ export class StringTranslations extends CrowdinApi {
      * @param labelIds filter translations by fileId
      * @param denormalizePlaceholders enable denormalize placeholders
      * @param croql filter translations by CroQL (Can't be used with `stringIds`, `labelIds` or `fileId` in same request)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.translations.getMany
      */
     listLanguageTranslations(
         projectId: number,
@@ -149,6 +154,7 @@ export class StringTranslations extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param denormalizePlaceholders enable denormalize placeholders
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.getMany
      */
     listStringTranslations(
         projectId: number,
@@ -168,6 +174,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.post
      */
     addTranslation(
         projectId: number,
@@ -181,6 +188,7 @@ export class StringTranslations extends CrowdinApi {
      * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.deleteMany
      */
     deleteAllTranslations(projectId: number, stringId: number, languageId: string): Promise<void> {
         let url = `${this.url}/projects/${projectId}/translations`;
@@ -192,6 +200,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param translationId translation identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.get
      */
     translationInfo(
         projectId: number,
@@ -204,15 +213,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param translation translation identifier
-     */
-    deleteTranslation(projectId: number, translationId: number): Promise<void> {
-        const url = `${this.url}/projects/${projectId}/translations/${translationId}`;
-        return this.delete(url, this.defaultConfig());
-    }
-
-    /**
-     * @param projectId project identifier
-     * @param translation translation identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.put
      */
     restoreTranslation(
         projectId: number,
@@ -224,11 +225,22 @@ export class StringTranslations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param translation translation identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.delete
+     */
+    deleteTranslation(projectId: number, translationId: number): Promise<void> {
+        const url = `${this.url}/projects/${projectId}/translations/${translationId}`;
+        return this.delete(url, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier
      * @param translationId translation identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.getMany
      */
     listTranslationVotes(
         projectId: number,
@@ -263,6 +275,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.post
      */
     addVote(
         projectId: number,
@@ -275,6 +288,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param voteId vote identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.get
      */
     voteInfo(projectId: number, voteId: number): Promise<ResponseObject<StringTranslationsModel.Vote>> {
         const url = `${this.url}/projects/${projectId}/votes/${voteId}`;
@@ -284,6 +298,7 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param voteId vote identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.delete
      */
     cancelVote(projectId: number, voteId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/votes/${voteId}`;

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -6,6 +6,7 @@ export class Tasks extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param status list tasks with specified statuses. It can be one status or a list of comma-separated status values
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.getMany
      */
     listTasks(
         projectId: number,
@@ -21,6 +22,7 @@ export class Tasks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.post
      */
     addTask(
         projectId: number,
@@ -35,6 +37,11 @@ export class Tasks extends CrowdinApi {
         return this.post(url, request, this.defaultConfig());
     }
 
+    /**
+     * @param projectId project identifier
+     * @param taskId task identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.exports.post
+     */
     exportTaskStrings(projectId: number, taskId: number): Promise<ResponseObject<DownloadLink>> {
         const url = `${this.url}/projects/${projectId}/tasks/${taskId}/exports`;
         return this.post(url, {}, this.defaultConfig());
@@ -43,6 +50,7 @@ export class Tasks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param taskId task identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.get
      */
     getTask(projectId: number, taskId: number): Promise<ResponseObject<TasksModel.Task>> {
         const url = `${this.url}/projects/${projectId}/tasks/${taskId}`;
@@ -52,6 +60,7 @@ export class Tasks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param taskId task identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.delete
      */
     deleteTask(projectId: number, taskId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/tasks/${taskId}`;
@@ -62,6 +71,7 @@ export class Tasks extends CrowdinApi {
      * @param projectId project identifier
      * @param taskId task identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.patch
      */
     editTask(projectId: number, taskId: number, request: PatchRequest[]): Promise<ResponseObject<TasksModel.Task>> {
         const url = `${this.url}/projects/${projectId}/tasks/${taskId}`;
@@ -73,6 +83,7 @@ export class Tasks extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param status list tasks with specified statuses. It can be one status or a list of comma-separated status values
      * @param isArchived list archived/not archived tasks for the authorized user. 1 - archived, 0 - not archived
+     * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.getMany
      */
     listUserTasks(
         limit?: number,
@@ -103,6 +114,7 @@ export class Tasks extends CrowdinApi {
      * @param projectId project identifier
      * @param taskId task identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.patch
      */
     editTaskArchivedStatus(
         projectId: number,

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -4,6 +4,7 @@ export class Teams extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.teams.post
      */
     addTeamToProject(
         projectId: number,
@@ -16,6 +17,7 @@ export class Teams extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
      */
     listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>> {
         const url = `${this.url}/teams`;
@@ -24,6 +26,7 @@ export class Teams extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.post
      */
     addTeam(request: TeamsModel.AddTeamRequest): Promise<ResponseObject<TeamsModel.Team>> {
         const url = `${this.url}/teams`;
@@ -32,6 +35,7 @@ export class Teams extends CrowdinApi {
 
     /**
      * @param teamId team identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.get
      */
     getTeam(teamId: number): Promise<ResponseObject<TeamsModel.Team>> {
         const url = `${this.url}/teams/${teamId}`;
@@ -40,6 +44,7 @@ export class Teams extends CrowdinApi {
 
     /**
      * @param teamId team identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.delete
      */
     deleteTeam(teamId: number): Promise<void> {
         const url = `${this.url}/teams/${teamId}`;
@@ -49,6 +54,7 @@ export class Teams extends CrowdinApi {
     /**
      * @param teamId team identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.patch
      */
     editTeam(teamId: number, request: PatchRequest[]): Promise<ResponseObject<TeamsModel.Team>> {
         const url = `${this.url}/teams/${teamId}`;
@@ -59,6 +65,7 @@ export class Teams extends CrowdinApi {
      * @param teamId team identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
      */
     teamMembersList(teamId: number, limit?: number, offset?: number): Promise<ResponseList<TeamsModel.TeamMember>> {
         const url = `${this.url}/teams/${teamId}/members`;
@@ -68,6 +75,7 @@ export class Teams extends CrowdinApi {
     /**
      * @param teamId team identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.post
      */
     addTeamMembers(
         teamId: number,
@@ -79,6 +87,7 @@ export class Teams extends CrowdinApi {
 
     /**
      * @param teamId team identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.deleteMany
      */
     deleteAllTeamMembers(teamId: number): Promise<void> {
         const url = `${this.url}/teams/${teamId}/members`;
@@ -88,6 +97,7 @@ export class Teams extends CrowdinApi {
     /**
      * @param teamId team identifier
      * @param memberId member identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.delete
      */
     deleteTeamMember(teamId: number, memberId: number): Promise<void> {
         const url = `${this.url}/teams/${teamId}/members/${memberId}`;

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -5,6 +5,7 @@ export class TranslationMemory extends CrowdinApi {
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
      */
     listTm(
         groupId?: number,
@@ -18,6 +19,7 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.post
      */
     addTm(
         request: TranslationMemoryModel.AddTranslationMemoryRequest,
@@ -28,6 +30,7 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param tmId tm identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.get
      */
     getTm(tmId: number): Promise<ResponseObject<TranslationMemoryModel.TranslationMemory>> {
         const url = `${this.url}/tms/${tmId}`;
@@ -36,6 +39,7 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param tmId tm identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.delete
      */
     deleteTm(tmId: number): Promise<void> {
         const url = `${this.url}/tms/${tmId}`;
@@ -45,6 +49,7 @@ export class TranslationMemory extends CrowdinApi {
     /**
      * @param tmId tm identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.patch
      */
     editTm(tmId: number, request: PatchRequest[]): Promise<ResponseObject<TranslationMemoryModel.TranslationMemory>> {
         const url = `${this.url}/tms/${tmId}`;
@@ -53,6 +58,7 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param tmId tm identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.segments.clear
      */
     clearTm(tmId: number): Promise<void> {
         const url = `${this.url}/tms/${tmId}/segments`;
@@ -61,16 +67,8 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param tmId tm identifier
-     * @param exportId export identifier
-     */
-    downloadTm(tmId: number, exportId: string): Promise<ResponseObject<DownloadLink>> {
-        const url = `${this.url}/tms/${tmId}/exports/${exportId}/download`;
-        return this.get(url, this.defaultConfig());
-    }
-
-    /**
-     * @param tmId tm identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.exports.post
      */
     exportTm(
         tmId: number,
@@ -83,6 +81,7 @@ export class TranslationMemory extends CrowdinApi {
     /**
      * @param tmId tm identifier
      * @param exportId export identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.exports.get
      */
     checkExportStatus(
         tmId: number,
@@ -94,7 +93,18 @@ export class TranslationMemory extends CrowdinApi {
 
     /**
      * @param tmId tm identifier
+     * @param exportId export identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.exports.download.download
+     */
+    downloadTm(tmId: number, exportId: string): Promise<ResponseObject<DownloadLink>> {
+        const url = `${this.url}/tms/${tmId}/exports/${exportId}/download`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
+     * @param tmId tm identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.imports.post
      */
     importTm(
         tmId: number,
@@ -107,6 +117,7 @@ export class TranslationMemory extends CrowdinApi {
     /**
      * @param tmId tm identifier
      * @param importId import identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.imports.get
      */
     checkImportStatus(
         tmId: number,

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -6,6 +6,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param branchId branch identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
      */
     getBranchProgress(
         projectId: number,
@@ -22,6 +23,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param directoryId directory identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
      */
     getDirectoryProgress(
         projectId: number,
@@ -35,9 +37,27 @@ export class TranslationStatus extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param fileId file identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
+     */
+    getFileProgress(
+        projectId: number,
+        fileId: number,
+        limit?: number,
+        offset?: number,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
+        const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
+        return this.getList(url, limit, offset);
+    }
+
+    /**
+     * @param projectId project identifier
      * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
      */
     getLanguageProgress(
         projectId: number,
@@ -54,6 +74,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param languageIds language identifier for filter
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
      */
     getProjectProgress(
         projectId: number,
@@ -68,27 +89,12 @@ export class TranslationStatus extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param fileId file identifier
-     * @param limit maximum number of items to retrieve (default 25)
-     * @param offset starting offset in the collection (default 0)
-     */
-    getFileProgress(
-        projectId: number,
-        fileId: number,
-        limit?: number,
-        offset?: number,
-    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
-        return this.getList(url, limit, offset);
-    }
-
-    /**
-     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param category defines the issue category
      * @param validation defines the QA check issue validation type
      * @param languageIds filter progress by languageId
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
      */
     listQaCheckIssues(
         projectId: number,
@@ -98,7 +104,6 @@ export class TranslationStatus extends CrowdinApi {
         validation?: TranslationStatusModel.Validation,
         languageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
-
     listQaCheckIssues(
         projectId: number,
         limitOrRequest?: number | TranslationStatusModel.ListQaCheckIssuesRequest,

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -3,19 +3,8 @@ import { CrowdinApi, DownloadLink, ResponseList, ResponseObject, Status } from '
 export class Translations extends CrowdinApi {
     /**
      * @param projectId project identifier
-     * @param request request body
-     */
-    applyPreTranslation(
-        projectId: number,
-        request: TranslationsModel.PreTranslateRequest,
-    ): Promise<ResponseObject<Status<TranslationsModel.PreTranslationStatusAttributes>>> {
-        const url = `${this.url}/projects/${projectId}/pre-translations`;
-        return this.post(url, request, this.defaultConfig());
-    }
-
-    /**
-     * @param projectId project identifier
      * @param preTranslationId pre translation identifier
+     * @see https://support.crowdin.com/api/v2/#tag/Translations/paths/~1projects~1{projectId}~1pre-translations~1{preTranslationId}/get
      */
     preTranslationStatus(
         projectId: number,
@@ -27,8 +16,22 @@ export class Translations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.pre-translations.post
+     */
+    applyPreTranslation(
+        projectId: number,
+        request: TranslationsModel.PreTranslateRequest,
+    ): Promise<ResponseObject<Status<TranslationsModel.PreTranslationStatusAttributes>>> {
+        const url = `${this.url}/projects/${projectId}/pre-translations`;
+        return this.post(url, request, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
      * @param directoryId directory identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.directories.post
      */
     buildProjectDirectoryTranslation(
         projectId: number,
@@ -45,6 +48,7 @@ export class Translations extends CrowdinApi {
      * @param fileId file identifier
      * @param request request body
      * @param eTag eTag 'If-None-Match' header
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post
      */
     buildProjectFileTranslation(
         projectId: number,
@@ -65,6 +69,7 @@ export class Translations extends CrowdinApi {
      * @param branchId branch identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.getMany
      */
     listProjectBuilds(
         projectId: number,
@@ -80,6 +85,7 @@ export class Translations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.post
      */
     buildProject(
         projectId: number,
@@ -91,35 +97,9 @@ export class Translations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param buildId build identifier
-     */
-    downloadTranslations(projectId: number, buildId: number): Promise<ResponseObject<DownloadLink>> {
-        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}/download`;
-        return this.get(url, this.defaultConfig());
-    }
-
-    /**
-     * @param projectId project identifier
-     * @param buildId build identifier
-     */
-    checkBuildStatus(projectId: number, buildId: number): Promise<ResponseObject<TranslationsModel.Build>> {
-        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}`;
-        return this.get(url, this.defaultConfig());
-    }
-
-    /**
-     * @param projectId project identifier
-     * @param buildId build identifier
-     */
-    cancelBuild(projectId: number, buildId: number): Promise<void> {
-        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}`;
-        return this.delete(url, this.defaultConfig());
-    }
-
-    /**
-     * @param projectId project identifier
      * @param languageId language identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage
      */
     uploadTranslation(
         projectId: number,
@@ -132,7 +112,38 @@ export class Translations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param buildId build identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.download.download
+     */
+    downloadTranslations(projectId: number, buildId: number): Promise<ResponseObject<DownloadLink>> {
+        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}/download`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param buildId build identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.get
+     */
+    checkBuildStatus(projectId: number, buildId: number): Promise<ResponseObject<TranslationsModel.Build>> {
+        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param buildId build identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.delete
+     */
+    cancelBuild(projectId: number, buildId: number): Promise<void> {
+        const url = `${this.url}/projects/${projectId}/translations/builds/${buildId}`;
+        return this.delete(url, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.exports.post
      */
     exportProjectTranslation(
         projectId: number,

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -914,6 +914,7 @@ export class UploadStorage extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
      */
     listStorages(limit?: number, offset?: number): Promise<ResponseList<UploadStorageModel.Storage>> {
         const url = `${this.url}/storages`;
@@ -924,6 +925,7 @@ export class UploadStorage extends CrowdinApi {
      * @param fileName file name
      * @param request binary file data
      * @param contentType content type header
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.post
      */
     addStorage(
         fileName: string,
@@ -949,6 +951,7 @@ export class UploadStorage extends CrowdinApi {
 
     /**
      * @param storageId storage identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.get
      */
     getStorage(storageId: number): Promise<ResponseObject<UploadStorageModel.Storage>> {
         const url = `${this.url}/storages/${storageId}`;
@@ -957,6 +960,7 @@ export class UploadStorage extends CrowdinApi {
 
     /**
      * @param storageId storage identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.delete
      */
     deleteStorage(storageId: number): Promise<void> {
         const url = `${this.url}/storages/${storageId}`;

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -9,6 +9,7 @@ export class Users extends CrowdinApi {
      * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
      */
     listProjectMembers(
         projectId: number,
@@ -18,7 +19,6 @@ export class Users extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
-
     listProjectMembers(
         projectId: number,
         searchOrRequest?: string | UsersModel.ListProjectMembersRequest,
@@ -44,6 +44,7 @@ export class Users extends CrowdinApi {
      *
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.post
      */
     addProjectMember(
         projectId: number,
@@ -57,6 +58,7 @@ export class Users extends CrowdinApi {
      *
      * @param projectId project identifier
      * @param memberId member identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.get
      */
     getProjectMemberPermissions(
         projectId: number,
@@ -70,6 +72,7 @@ export class Users extends CrowdinApi {
      *
      * @param projectId project identifier
      * @param memberId member identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.put
      */
     replaceProjectMemberPermissions(
         projectId: number,
@@ -84,6 +87,7 @@ export class Users extends CrowdinApi {
      *
      * @param projectId project identifier
      * @param memberId member identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.delete
      */
     deleteMemberFromProject(projectId: number, memberId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/members/${memberId}`;
@@ -96,6 +100,7 @@ export class Users extends CrowdinApi {
      * @param twoFactor filter users by two-factor authentication status
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
      */
     listUsers(
         status?: UsersModel.Status,
@@ -104,7 +109,6 @@ export class Users extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<UsersModel.User>>;
-
     listUsers(
         statusOrRequest?: UsersModel.Status | UsersModel.ListUsersRequest,
         search?: string,
@@ -127,12 +131,16 @@ export class Users extends CrowdinApi {
 
     /**
      * @param userId user identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getById
      */
     getUserInfo(userId: number): Promise<ResponseObject<UsersModel.User>> {
         const url = `${this.url}/users/${userId}`;
         return this.get(url, this.defaultConfig());
     }
 
+    /**
+     * @see https://support.crowdin.com/api/v2/#operation/api.user.get
+     */
     getAuthenticatedUser(): Promise<ResponseObject<UsersModel.User>> {
         const url = `${this.url}/user`;
         return this.get(url, this.defaultConfig());

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -4,6 +4,7 @@ export class Vendors extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
      */
     listVendors(limit?: number, offset?: number): Promise<ResponseList<VendorsModel.Vendor>> {
         const url = `${this.url}/vendors`;

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -5,6 +5,7 @@ export class Webhooks extends CrowdinApi {
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
      */
     listWebhooks(projectId: number, limit?: number, offset?: number): Promise<ResponseList<WebhooksModel.Webhook>> {
         const url = `${this.url}/projects/${projectId}/webhooks`;
@@ -14,6 +15,7 @@ export class Webhooks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.post
      */
     addWebhook(
         projectId: number,
@@ -26,6 +28,7 @@ export class Webhooks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param webhookId webhook identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.get
      */
     getWebhook(projectId: number, webhookId: number): Promise<ResponseObject<WebhooksModel.Webhook>> {
         const url = `${this.url}/projects/${projectId}/webhooks/${webhookId}`;
@@ -35,6 +38,7 @@ export class Webhooks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param webhookId webhook identifier
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.delete
      */
     deleteWebhook(projectId: number, webhookId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/webhooks/${webhookId}`;
@@ -45,6 +49,7 @@ export class Webhooks extends CrowdinApi {
      * @param projectId project identifier
      * @param webhookId webhook identifier
      * @param request request body
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.patch
      */
     editWebhook(
         projectId: number,

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -5,13 +5,13 @@ export class Workflows extends CrowdinApi {
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.getMany
      */
     listWorkflowTemplates(
         groupId?: number,
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>>;
-
     listWorkflowTemplates(
         groupIdOrRequest?: number | WorkflowModel.ListWorkflowTemplatesRequest,
         limit?: number,
@@ -30,6 +30,7 @@ export class Workflows extends CrowdinApi {
 
     /**
      * @param templateId workflow template identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.get
      */
     getWorkflowTemplateInfo(templateId: number): Promise<ResponseObject<WorkflowModel.Workflow>> {
         const url = `${this.url}/workflow-templates/${templateId}`;


### PR DESCRIPTION
This PR adds links to the API documentation on Crowdin's website for all methods. I have also reordered some methods to match the documentation order