### PR TITLE
feat(Workflows): add workflow steps methods

### DIFF
--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -2,6 +2,34 @@ import { CrowdinApi, ResponseList, ResponseObject } from '../core';
 
 export class Workflows extends CrowdinApi {
     /**
+     * @param projectId project identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.workflow-steps.getMany
+     */
+    listWorkflowSteps(
+        projectId: number,
+        limit?: number,
+        offset?: number,
+    ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>> {
+        const url = `${this.url}/projects/${projectId}/workflow-steps`;
+        return this.getList(url, limit, offset);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param stepId workflow step identifier
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.workflow-steps.getMany
+     */
+    getWorkflowStep(
+        projectId: number,
+        stepId: number,
+    ): Promise<ResponseObject<WorkflowModel.ListWorkflowStepsResponse>> {
+        const url = `${this.url}/projects/${projectId}/workflow-steps/${stepId}`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
@@ -38,6 +66,19 @@ export class Workflows extends CrowdinApi {
 }
 
 export namespace WorkflowModel {
+    export interface ListWorkflowStepsResponse {
+        id: number;
+        title: string;
+        type: string;
+        languages: string[];
+        config:
+            | {
+                  minRelevant: string;
+                  autoSubstitution: number;
+                  assignees: Record<string, number[]>;
+              }
+            | never[];
+    }
     export interface ListWorkflowTemplatesRequest {
         groupId?: number;
         limit?: number;

--- a/tests/workflows/api.test.ts
+++ b/tests/workflows/api.test.ts
@@ -9,11 +9,40 @@ describe('Workflows API', () => {
     };
     const api: Workflows = new Workflows(credentials);
     const id = 2;
+    const projectId = 4;
 
     const limit = 25;
 
     beforeAll(() => {
         scope = nock(api.url)
+            .get(`/projects/${projectId}/workflow-steps`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: id,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get(`/projects/${projectId}/workflow-steps/${id}`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .reply(200, {
+                data: {
+                    id: id,
+                },
+            })
             .get('/workflow-templates', undefined, {
                 reqheaders: {
                     Authorization: `Bearer ${api.token}`,
@@ -46,6 +75,18 @@ describe('Workflows API', () => {
 
     afterAll(() => {
         scope.done();
+    });
+
+    it('List Workflow steps', async () => {
+        const workflowSteps = await api.listWorkflowSteps(projectId);
+        expect(workflowSteps.data.length).toBe(1);
+        expect(workflowSteps.data[0].data.id).toBe(id);
+        expect(workflowSteps.pagination.limit).toBe(limit);
+    });
+
+    it('Get Workflow step info', async () => {
+        const workflowStep = await api.getWorkflowStep(projectId, id);
+        expect(workflowStep.data.id).toBe(id);
     });
 
     it('List Workflow Templates', async () => {


### PR DESCRIPTION
This PR adds two missing methods from the Crowdin Enterprise API to the workflows API. Ideally this should be merged after #148 as it integrates the features added in that PR as well