### PR TITLE
refactor: allow optional parameters to be passed through objects

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,6 +49,8 @@ export interface Pagination {
     limit: number;
 }
 
+export type PaginationOptions = Partial<Pagination>;
+
 export interface ValidationErrorResponse {
     errors: ErrorHolder[];
 }
@@ -124,6 +126,7 @@ export abstract class CrowdinApi {
 
     protected fetchAllFlag = false;
     protected maxLimit: number | undefined;
+    protected deprecationEmittedForOptionalParams = false;
 
     /**
      * @param credentials credentials
@@ -257,6 +260,16 @@ export abstract class CrowdinApi {
             }
         }
         return resp;
+    }
+
+    protected emitDeprecationWarning(): void {
+        if (!this.deprecationEmittedForOptionalParams) {
+            process.emitWarning(
+                'Passing optional parameters individually is deprecated. Pass a sole object instead',
+                'DeprecationWarning',
+            );
+            this.deprecationEmittedForOptionalParams = true;
+        }
     }
 
     //Http overrides

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -126,7 +126,6 @@ export abstract class CrowdinApi {
 
     protected fetchAllFlag = false;
     protected maxLimit: number | undefined;
-    protected deprecationEmittedForOptionalParams = false;
 
     /**
      * @param credentials credentials
@@ -262,16 +261,6 @@ export abstract class CrowdinApi {
         return resp;
     }
 
-    protected emitDeprecationWarning(): void {
-        if (!this.deprecationEmittedForOptionalParams) {
-            process.emitWarning(
-                'Passing optional parameters individually is deprecated. Pass a sole object instead',
-                'DeprecationWarning',
-            );
-            this.deprecationEmittedForOptionalParams = true;
-        }
-    }
-
     //Http overrides
 
     protected get<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
@@ -296,5 +285,17 @@ export abstract class CrowdinApi {
 
     protected patch<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.patch(url, data, config));
+    }
+}
+
+let deprecationEmittedForOptionalParams = false;
+
+export function emitDeprecationWarning(): void {
+    if (!deprecationEmittedForOptionalParams) {
+        process.emitWarning(
+            'Passing optional parameters individually is deprecated. Pass a sole object instead',
+            'DeprecationWarning',
+        );
+        deprecationEmittedForOptionalParams = true;
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -290,12 +290,29 @@ export abstract class CrowdinApi {
 
 let deprecationEmittedForOptionalParams = false;
 
-export function emitDeprecationWarning(): void {
+function emitDeprecationWarning(): void {
     if (!deprecationEmittedForOptionalParams) {
         process.emitWarning(
             'Passing optional parameters individually is deprecated. Pass a sole object instead',
             'DeprecationWarning',
         );
         deprecationEmittedForOptionalParams = true;
+    }
+}
+
+export function isOptionalString(parameter?: string | unknown): parameter is string | undefined {
+    if (typeof parameter === 'string' || typeof parameter === 'undefined') {
+        emitDeprecationWarning();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+export function isOptionalNumber(parameter?: number | unknown): parameter is number | undefined {
+    if (typeof parameter === 'number' || typeof parameter === 'undefined') {
+        return true;
+    } else {
+        return false;
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -292,10 +292,16 @@ let deprecationEmittedForOptionalParams = false;
 
 function emitDeprecationWarning(): void {
     if (!deprecationEmittedForOptionalParams) {
-        process.emitWarning(
-            'Passing optional parameters individually is deprecated. Pass a sole object instead',
-            'DeprecationWarning',
-        );
+        if (typeof process !== 'undefined') {
+            process.emitWarning(
+                'Passing optional parameters individually is deprecated. Pass a sole object instead',
+                'DeprecationWarning',
+            );
+        } else {
+            console.warn(
+                'DeprecationWarning: Passing optional parameters individually is deprecated. Pass a sole object instead',
+            );
+        }
         deprecationEmittedForOptionalParams = true;
     }
 }
@@ -311,6 +317,7 @@ export function isOptionalString(parameter?: string | unknown): parameter is str
 
 export function isOptionalNumber(parameter?: number | unknown): parameter is number | undefined {
     if (typeof parameter === 'number' || typeof parameter === 'undefined') {
+        emitDeprecationWarning();
         return true;
     } else {
         return false;

--- a/src/core/internal/retry/index.ts
+++ b/src/core/internal/retry/index.ts
@@ -15,7 +15,6 @@ export class RetryService {
     constructor(private config: RetryConfig) {}
 
     /**
-     *
      * @param func function to execute
      */
     async executeAsyncFunc<T>(func: () => Promise<T>): Promise<T> {
@@ -35,7 +34,6 @@ export class RetryService {
     }
 
     /**
-     *
      * @param func function to execute
      */
     async executeSyncFunc<T>(func: () => T): Promise<T> {

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -3,15 +3,17 @@ import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core'
 export class Dictionaries extends CrowdinApi {
     /**
      * @param projectId project identifier
-     * @param options Optional options for listing dictionaries
+     * @param options optional parameters for listing dictionaries
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.dictionaries.getMany
      */
     listDictionaries(
         projectId: number,
-        options: DictionariesModel.ListDictionariesOptions,
+        options?: DictionariesModel.ListDictionariesOptions,
     ): Promise<ResponseList<DictionariesModel.Dictionary>>;
     /**
      * @param projectId project identifier
      * @param languageIds filter progress by Language Identifiers
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.dictionaries.getMany
      */
     listDictionaries(projectId: number, languageIds?: string): Promise<ResponseList<DictionariesModel.Dictionary>>;

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, emitDeprecationWarning, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, isOptionalString, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Dictionaries extends CrowdinApi {
     /**
@@ -21,9 +21,8 @@ export class Dictionaries extends CrowdinApi {
         projectId: number,
         options?: string | DictionariesModel.ListDictionariesOptions,
     ): Promise<ResponseList<DictionariesModel.Dictionary>> {
-        if (typeof options === 'string' || typeof options === 'undefined') {
+        if (isOptionalString(options)) {
             options = { languageIds: options };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/dictionaries`;
         url = this.addQueryParam(url, 'languageIds', options.languageIds);

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -3,12 +3,28 @@ import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core'
 export class Dictionaries extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options Optional options for listing dictionaries
+     */
+    listDictionaries(
+        projectId: number,
+        options: DictionariesModel.ListDictionariesOptions,
+    ): Promise<ResponseList<DictionariesModel.Dictionary>>;
+    /**
+     * @param projectId project identifier
      * @param languageIds filter progress by Language Identifiers
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.dictionaries.getMany
      */
-    listDictionaries(projectId: number, languageIds?: string): Promise<ResponseList<DictionariesModel.Dictionary>> {
+    listDictionaries(projectId: number, languageIds?: string): Promise<ResponseList<DictionariesModel.Dictionary>>;
+    listDictionaries(
+        projectId: number,
+        options: string | DictionariesModel.ListDictionariesOptions = {},
+    ): Promise<ResponseList<DictionariesModel.Dictionary>> {
+        if (typeof options === 'string') {
+            options = { languageIds: options };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects/${projectId}/dictionaries`;
-        url = this.addQueryParam(url, 'languageIds', languageIds);
+        url = this.addQueryParam(url, 'languageIds', options.languageIds);
         return this.get(url, this.defaultConfig());
     }
 
@@ -32,5 +48,9 @@ export namespace DictionariesModel {
     export interface Dictionary {
         languageId: string;
         words: string[];
+    }
+
+    export interface ListDictionariesOptions {
+        languageIds?: string;
     }
 }

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -17,9 +17,9 @@ export class Dictionaries extends CrowdinApi {
     listDictionaries(projectId: number, languageIds?: string): Promise<ResponseList<DictionariesModel.Dictionary>>;
     listDictionaries(
         projectId: number,
-        options: string | DictionariesModel.ListDictionariesOptions = {},
+        options?: string | DictionariesModel.ListDictionariesOptions,
     ): Promise<ResponseList<DictionariesModel.Dictionary>> {
-        if (typeof options === 'string') {
+        if (typeof options === 'string' || typeof options === 'undefined') {
             options = { languageIds: options };
             this.emitDeprecationWarning();
         }

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, emitDeprecationWarning, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Dictionaries extends CrowdinApi {
     /**
@@ -23,7 +23,7 @@ export class Dictionaries extends CrowdinApi {
     ): Promise<ResponseList<DictionariesModel.Dictionary>> {
         if (typeof options === 'string' || typeof options === 'undefined') {
             options = { languageIds: options };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/dictionaries`;
         url = this.addQueryParam(url, 'languageIds', options.languageIds);

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -22,10 +22,10 @@ export class Distributions extends CrowdinApi {
     ): Promise<ResponseList<DistributionsModel.Distribution>>;
     listDistributions(
         projectId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<DistributionsModel.Distribution>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Distributions extends CrowdinApi {
     /**
@@ -29,7 +36,7 @@ export class Distributions extends CrowdinApi {
     ): Promise<ResponseList<DistributionsModel.Distribution>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/distributions`;
         return this.getList(url, options.limit, options.offset);

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -3,16 +3,18 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 export class Distributions extends CrowdinApi {
     /**
      * @param projectId project identifier
-     * @param options Optional pagination options for the request
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.getMany
      */
     listDistributions(
         projectId: number,
-        options: PaginationOptions,
+        options?: PaginationOptions,
     ): Promise<ResponseList<DistributionsModel.Distribution>>;
     /**
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.distributions.getMany
      */
     listDistributions(

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Distributions extends CrowdinApi {
     /**
@@ -34,9 +27,8 @@ export class Distributions extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<DistributionsModel.Distribution>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/distributions`;
         return this.getList(url, options.limit, options.offset);

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -1,6 +1,14 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Distributions extends CrowdinApi {
+    /**
+     * @param projectId project identifier
+     * @param options Optional pagination options for the request
+     */
+    listDistributions(
+        projectId: number,
+        options: PaginationOptions,
+    ): Promise<ResponseList<DistributionsModel.Distribution>>;
     /**
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
@@ -11,9 +19,18 @@ export class Distributions extends CrowdinApi {
         projectId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<DistributionsModel.Distribution>>;
+    listDistributions(
+        projectId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<DistributionsModel.Distribution>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/distributions`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -143,7 +143,7 @@ export class Glossaries extends CrowdinApi {
      */
     listTerms(
         glossaryId: number,
-        options?: GlossariesModel.ListTermsRequest,
+        options?: GlossariesModel.ListTermsOptions,
     ): Promise<ResponseList<GlossariesModel.Term>>;
     /**
      * @param glossaryId glossary identifier
@@ -165,7 +165,7 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseList<GlossariesModel.Term>>;
     listTerms(
         glossaryId: number,
-        options?: number | GlossariesModel.ListTermsRequest,
+        options?: number | GlossariesModel.ListTermsOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
         deprecatedLanguageId?: string,
@@ -312,7 +312,7 @@ export namespace GlossariesModel {
         firstLineContainsHeader?: boolean;
     }
 
-    export interface ListTermsRequest extends PaginationOptions {
+    export interface ListTermsOptions extends PaginationOptions {
         userId?: number;
         languageId?: string;
         translationOfTermId?: number;

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -10,14 +10,15 @@ import {
 
 export class Glossaries extends CrowdinApi {
     /**
-     * @param options Optional options for the request
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.getMany
      */
-    listGlossaries(options: GlossariesModel.ListGlossariesOptions): Promise<ResponseList<GlossariesModel.Glossary>>;
+    listGlossaries(options?: GlossariesModel.ListGlossariesOptions): Promise<ResponseList<GlossariesModel.Glossary>>;
     /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.getMany
      */
     listGlossaries(groupId?: number, limit?: number, offset?: number): Promise<ResponseList<GlossariesModel.Glossary>>;
@@ -137,12 +138,12 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param glossaryId glossary identifier
-     * @param options optional options for the request
+     * @param options optional parameters for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
      */
     listTerms(
         glossaryId: number,
-        options: GlossariesModel.ListTermsRequest,
+        options?: GlossariesModel.ListTermsRequest,
     ): Promise<ResponseList<GlossariesModel.Term>>;
     /**
      * @param glossaryId glossary identifier
@@ -151,7 +152,7 @@ export class Glossaries extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param languageId term language identifier
      * @param translationOfTermId filter terms by termId
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
      */
     listTerms(
@@ -200,15 +201,20 @@ export class Glossaries extends CrowdinApi {
         return this.post(url, request, this.defaultConfig());
     }
 
+    /**
+     * @param glossaryId glossary identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.deleteMany
+     */
     clearGlossary(
         glossaryId: number,
-        options: GlossariesModel.ClearGlossaryOptions,
+        options?: GlossariesModel.ClearGlossaryOptions,
     ): Promise<ResponseObject<GlossariesModel.Term>>;
     /**
      * @param glossaryId glossary identifier
      * @param languageId languageId identifier
      * @param translationOfTermId term translation identifier
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.deleteMany
      */
     clearGlossary(

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -1,13 +1,36 @@
-import { CrowdinApi, DownloadLink, PatchRequest, ResponseList, ResponseObject, Status } from '../core';
+import {
+    CrowdinApi,
+    DownloadLink,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+    Status,
+} from '../core';
 
 export class Glossaries extends CrowdinApi {
+    /**
+     * @param options Optional options for the request
+     */
+    listGlossaries(options: GlossariesModel.ListGlossariesOptions): Promise<ResponseList<GlossariesModel.Glossary>>;
     /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.getMany
      */
-    listGlossaries(groupId?: number, limit?: number, offset?: number): Promise<ResponseList<GlossariesModel.Glossary>> {
+    listGlossaries(groupId?: number, limit?: number, offset?: number): Promise<ResponseList<GlossariesModel.Glossary>>;
+    listGlossaries(
+        options: number | GlossariesModel.ListGlossariesOptions = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<GlossariesModel.Glossary>> {
+        if (typeof options === 'number') {
+            options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
+        const { groupId, limit, offset } = options;
         let url = `${this.url}/glossaries`;
         url = this.addQueryParam(url, 'groupId', groupId);
         return this.getList(url, limit, offset);
@@ -114,12 +137,12 @@ export class Glossaries extends CrowdinApi {
 
     /**
      * @param glossaryId glossary identifier
-     * @param request request body
+     * @param options optional options for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
      */
     listTerms(
         glossaryId: number,
-        request: GlossariesModel.ListTermsRequest,
+        options: GlossariesModel.ListTermsRequest,
     ): Promise<ResponseList<GlossariesModel.Term>>;
     /**
      * @param glossaryId glossary identifier
@@ -128,6 +151,7 @@ export class Glossaries extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param languageId term language identifier
      * @param translationOfTermId filter terms by termId
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.getMany
      */
     listTerms(
@@ -140,23 +164,27 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseList<GlossariesModel.Term>>;
     listTerms(
         glossaryId: number,
-        userIdOrRequest?: number | GlossariesModel.ListTermsRequest,
-        limit?: number,
-        offset?: number,
-        languageId?: string,
-        translationOfTermId?: number,
+        options: number | GlossariesModel.ListTermsRequest = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+        deprecatedLanguageId?: string,
+        deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseList<GlossariesModel.Term>> {
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
-        let request: GlossariesModel.ListTermsRequest;
-        if (userIdOrRequest && typeof userIdOrRequest === 'object') {
-            request = userIdOrRequest;
-        } else {
-            request = { userId: userIdOrRequest, limit, offset, languageId, translationOfTermId };
+        if (typeof options === 'number') {
+            options = {
+                userId: options,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+                languageId: deprecatedLanguageId,
+                translationOfTermId: deprecatedTranslationOfTermId,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'userId', request.userId);
-        url = this.addQueryParam(url, 'languageId', request.languageId);
-        url = this.addQueryParam(url, 'translationOfTermId', request.translationOfTermId);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'userId', options.userId);
+        url = this.addQueryParam(url, 'languageId', options.languageId);
+        url = this.addQueryParam(url, 'translationOfTermId', options.translationOfTermId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -172,20 +200,34 @@ export class Glossaries extends CrowdinApi {
         return this.post(url, request, this.defaultConfig());
     }
 
+    clearGlossary(
+        glossaryId: number,
+        options: GlossariesModel.ClearGlossaryOptions,
+    ): Promise<ResponseObject<GlossariesModel.Term>>;
     /**
      * @param glossaryId glossary identifier
      * @param languageId languageId identifier
      * @param translationOfTermId term translation identifier
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.glossaries.terms.deleteMany
      */
     clearGlossary(
         glossaryId: number,
         languageId?: number,
         translationOfTermId?: number,
+    ): Promise<ResponseObject<GlossariesModel.Term>>;
+    clearGlossary(
+        glossaryId: number,
+        options: number | GlossariesModel.ClearGlossaryOptions = {},
+        deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseObject<GlossariesModel.Term>> {
+        if (typeof options === 'number') {
+            options = { languageId: options, translationOfTermId: deprecatedTranslationOfTermId };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
-        url = this.addQueryParam(url, 'languageId', languageId);
-        url = this.addQueryParam(url, 'translationOfTermId', translationOfTermId);
+        url = this.addQueryParam(url, 'languageId', options.languageId);
+        url = this.addQueryParam(url, 'translationOfTermId', options.translationOfTermId);
         return this.delete(url, this.defaultConfig());
     }
 
@@ -264,10 +306,8 @@ export namespace GlossariesModel {
         firstLineContainsHeader?: boolean;
     }
 
-    export interface ListTermsRequest {
+    export interface ListTermsRequest extends PaginationOptions {
         userId?: number;
-        limit?: number;
-        offset?: number;
         languageId?: string;
         translationOfTermId?: number;
     }
@@ -319,5 +359,14 @@ export namespace GlossariesModel {
         SUBORDINATING_CONJUNCTION = 'subordinating conjunction',
         VERB = 'verb',
         OTHER = 'other',
+    }
+
+    export interface ListGlossariesOptions extends PaginationOptions {
+        groupId?: number;
+    }
+
+    export interface ClearGlossaryOptions {
+        languageId?: number;
+        translationOfTermId?: number;
     }
 }

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -22,11 +22,11 @@ export class Glossaries extends CrowdinApi {
      */
     listGlossaries(groupId?: number, limit?: number, offset?: number): Promise<ResponseList<GlossariesModel.Glossary>>;
     listGlossaries(
-        options: number | GlossariesModel.ListGlossariesOptions = {},
+        options?: number | GlossariesModel.ListGlossariesOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<GlossariesModel.Glossary>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -164,14 +164,14 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseList<GlossariesModel.Term>>;
     listTerms(
         glossaryId: number,
-        options: number | GlossariesModel.ListTermsRequest = {},
+        options?: number | GlossariesModel.ListTermsRequest,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
         deprecatedLanguageId?: string,
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseList<GlossariesModel.Term>> {
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 userId: options,
                 limit: deprecatedLimit,
@@ -218,10 +218,10 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseObject<GlossariesModel.Term>>;
     clearGlossary(
         glossaryId: number,
-        options: number | GlossariesModel.ClearGlossaryOptions = {},
+        options?: number | GlossariesModel.ClearGlossaryOptions,
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseObject<GlossariesModel.Term>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { languageId: options, translationOfTermId: deprecatedTranslationOfTermId };
             this.emitDeprecationWarning();
         }

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -32,10 +32,9 @@ export class Glossaries extends CrowdinApi {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             emitDeprecationWarning();
         }
-        const { groupId, limit, offset } = options;
         let url = `${this.url}/glossaries`;
-        url = this.addQueryParam(url, 'groupId', groupId);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'groupId', options.groupId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -1,6 +1,7 @@
 import {
     CrowdinApi,
     DownloadLink,
+    emitDeprecationWarning,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -29,7 +30,7 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseList<GlossariesModel.Glossary>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const { groupId, limit, offset } = options;
         let url = `${this.url}/glossaries`;
@@ -180,7 +181,7 @@ export class Glossaries extends CrowdinApi {
                 languageId: deprecatedLanguageId,
                 translationOfTermId: deprecatedTranslationOfTermId,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'userId', options.userId);
         url = this.addQueryParam(url, 'languageId', options.languageId);
@@ -229,7 +230,7 @@ export class Glossaries extends CrowdinApi {
     ): Promise<ResponseObject<GlossariesModel.Term>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { languageId: options, translationOfTermId: deprecatedTranslationOfTermId };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
         url = this.addQueryParam(url, 'languageId', options.languageId);

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -1,7 +1,7 @@
 import {
     CrowdinApi,
     DownloadLink,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -28,9 +28,8 @@ export class Glossaries extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<GlossariesModel.Glossary>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/glossaries`;
         url = this.addQueryParam(url, 'groupId', options.groupId);
@@ -172,7 +171,7 @@ export class Glossaries extends CrowdinApi {
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseList<GlossariesModel.Term>> {
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 userId: options,
                 limit: deprecatedLimit,
@@ -180,7 +179,6 @@ export class Glossaries extends CrowdinApi {
                 languageId: deprecatedLanguageId,
                 translationOfTermId: deprecatedTranslationOfTermId,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'userId', options.userId);
         url = this.addQueryParam(url, 'languageId', options.languageId);
@@ -227,9 +225,8 @@ export class Glossaries extends CrowdinApi {
         options?: number | GlossariesModel.ClearGlossaryOptions,
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseObject<GlossariesModel.Term>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { languageId: options, translationOfTermId: deprecatedTranslationOfTermId };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
         url = this.addQueryParam(url, 'languageId', options.languageId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export default class Client {
     readonly usersApi: Users;
     readonly vendorsApi: Vendors;
     /**
-     * @deprecated
+     * @deprecated use stringCommentsApi instead
      */
     readonly issuesApi: Issues;
     readonly teamsApi: Teams;

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -30,12 +30,12 @@ export class Issues extends CrowdinApi {
     ): Promise<ResponseList<IssuesModel.Issue>>;
     listReportedIssues(
         projectId: number,
-        options: number | IssuesModel.ListReportedIssuesOptions = {},
+        options?: number | IssuesModel.ListReportedIssuesOptions,
         deprecatedOffset?: number,
         deprecatedType?: IssuesModel.Type,
         deprecatedStatus?: IssuesModel.Status,
     ): Promise<ResponseList<IssuesModel.Issue>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -6,7 +6,8 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 export class Issues extends CrowdinApi {
     /**
      * @param projectId project identifier
-     * @param options optional options for listing reported issues
+     * @param options optional parameters for listing reported issues
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.issues.getMany
      */
     listReportedIssues(
         projectId: number,
@@ -18,7 +19,7 @@ export class Issues extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param type defines the issue type
      * @param status defines the issue resolution status
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.issues.getMany
      */
     listReportedIssues(

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 /**
  * @deprecated
@@ -43,14 +36,13 @@ export class Issues extends CrowdinApi {
         deprecatedType?: IssuesModel.Type,
         deprecatedStatus?: IssuesModel.Status,
     ): Promise<ResponseList<IssuesModel.Issue>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
                 type: deprecatedType,
                 status: deprecatedStatus,
             };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/issues`;
         url = this.addQueryParam(url, 'type', options.type);

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 /**
  * @deprecated
@@ -43,7 +50,7 @@ export class Issues extends CrowdinApi {
                 type: deprecatedType,
                 status: deprecatedStatus,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/issues`;
         url = this.addQueryParam(url, 'type', options.type);

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 import { SourceStringsModel } from '../sourceStrings';
 
 export class Labels extends CrowdinApi {
@@ -6,11 +6,21 @@ export class Labels extends CrowdinApi {
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.getMany
      */
-    listLabels(projectId: number, limit?: number, offset?: number): Promise<ResponseList<LabelsModel.Label>> {
+    listLabels(projectId: number, limit?: number, offset?: number): Promise<ResponseList<LabelsModel.Label>>;
+    listLabels(
+        projectId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<LabelsModel.Label>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/labels`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 import { SourceStringsModel } from '../sourceStrings';
 
 export class Labels extends CrowdinApi {
@@ -23,7 +30,7 @@ export class Labels extends CrowdinApi {
     ): Promise<ResponseList<LabelsModel.Label>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/labels`;
         return this.getList(url, options.limit, options.offset);

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -12,10 +12,10 @@ export class Labels extends CrowdinApi {
     listLabels(projectId: number, limit?: number, offset?: number): Promise<ResponseList<LabelsModel.Label>>;
     listLabels(
         projectId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LabelsModel.Label>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 import { SourceStringsModel } from '../sourceStrings';
 
 export class Labels extends CrowdinApi {
@@ -28,9 +21,8 @@ export class Labels extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LabelsModel.Label>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/labels`;
         return this.getList(url, options.limit, options.offset);

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -4,9 +4,15 @@ import { SourceStringsModel } from '../sourceStrings';
 export class Labels extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.getMany
+     */
+    listLabels(projectId: number, options?: PaginationOptions): Promise<ResponseList<LabelsModel.Label>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.labels.getMany
      */
     listLabels(projectId: number, limit?: number, offset?: number): Promise<ResponseList<LabelsModel.Label>>;

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Languages extends CrowdinApi {
     /**
@@ -19,7 +26,7 @@ export class Languages extends CrowdinApi {
     ): Promise<ResponseList<LanguagesModel.Language>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/languages`;
         return this.getList(url, options.limit, options.offset);

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -13,10 +13,10 @@ export class Languages extends CrowdinApi {
      */
     listSupportedLanguages(options: PaginationOptions): Promise<ResponseList<LanguagesModel.Language>>;
     listSupportedLanguages(
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LanguagesModel.Language>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,14 +1,27 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Languages extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.languages.getMany
      */
-    listSupportedLanguages(limit?: number, offset?: number): Promise<ResponseList<LanguagesModel.Language>> {
+    listSupportedLanguages(limit?: number, offset?: number): Promise<ResponseList<LanguagesModel.Language>>;
+    /**
+     * @param options optional pagination options for the request
+     */
+    listSupportedLanguages(options: PaginationOptions): Promise<ResponseList<LanguagesModel.Language>>;
+    listSupportedLanguages(
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<LanguagesModel.Language>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/languages`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -2,16 +2,17 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 
 export class Languages extends CrowdinApi {
     /**
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.languages.getMany
+     */
+    listSupportedLanguages(options?: PaginationOptions): Promise<ResponseList<LanguagesModel.Language>>;
+    /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.languages.getMany
      */
     listSupportedLanguages(limit?: number, offset?: number): Promise<ResponseList<LanguagesModel.Language>>;
-    /**
-     * @param options optional pagination options for the request
-     */
-    listSupportedLanguages(options: PaginationOptions): Promise<ResponseList<LanguagesModel.Language>>;
     listSupportedLanguages(
         options?: number | PaginationOptions,
         deprecatedOffset?: number,

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Languages extends CrowdinApi {
     /**
@@ -24,9 +17,8 @@ export class Languages extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LanguagesModel.Language>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/languages`;
         return this.getList(url, options.limit, options.offset);

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -20,11 +20,11 @@ export class MachineTranslation extends CrowdinApi {
         options?: MachineTranslationModel.ListMTsOptions,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
     listMts(
-        options: number | MachineTranslationModel.ListMTsOptions = {},
+        options?: number | MachineTranslationModel.ListMTsOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -2,22 +2,23 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 
 export class MachineTranslation extends CrowdinApi {
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.mts.getMany
+     */
+    listMts(
+        options?: MachineTranslationModel.ListMTsOptions,
+    ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
+    /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.mts.getMany
      */
     listMts(
         groupId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
-    /**
-     * @param options optional options for the request
-     */
-    listMts(
-        options?: MachineTranslationModel.ListMTsOptions,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
     listMts(
         options?: number | MachineTranslationModel.ListMTsOptions,
@@ -76,7 +77,6 @@ export class MachineTranslation extends CrowdinApi {
     }
 
     /**
-     *
      * @param mtId mt identifier
      * @param request request body
      * @see https://support.crowdin.com/api/v2/#operation/api.mts.translations.post

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class MachineTranslation extends CrowdinApi {
     /**
@@ -27,7 +34,7 @@ export class MachineTranslation extends CrowdinApi {
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/mts`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class MachineTranslation extends CrowdinApi {
     /**
@@ -32,9 +25,8 @@ export class MachineTranslation extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/mts`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -1,20 +1,36 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class MachineTranslation extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.mts.getMany
      */
     listMts(
         groupId?: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
+    /**
+     * @param options optional options for the request
+     */
+    listMts(
+        options?: MachineTranslationModel.ListMTsOptions,
+    ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>>;
+    listMts(
+        options: number | MachineTranslationModel.ListMTsOptions = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>> {
+        if (typeof options === 'number') {
+            options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/mts`;
-        url = this.addQueryParam(url, 'groupId', groupId);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'groupId', options.groupId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -112,5 +128,9 @@ export namespace MachineTranslationModel {
     export enum LanguageRecognitionProvider {
         CROWDIN = 'crowdin',
         ENGINE = 'engine',
+    }
+
+    export interface ListMTsOptions extends PaginationOptions {
+        groupId?: number;
     }
 }

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -1,7 +1,7 @@
 import {
     BooleanInt,
     CrowdinApi,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -35,14 +35,13 @@ export class ProjectsGroups extends CrowdinApi {
         deprecatedUserId?: number,
         deprecatedLimit?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Group>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 parentId: options,
                 offset: deprecatedOffset,
                 userId: deprecatedUserId,
                 limit: deprecatedLimit,
             };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/groups`;
         url = this.addQueryParam(url, 'parentId', options.parentId);
@@ -114,14 +113,13 @@ export class ProjectsGroups extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 groupId: options,
                 hasManagerAccess: deprecatedHasManagerAccess,
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -3,11 +3,16 @@ import { LanguagesModel } from '../languages';
 
 export class ProjectsGroups extends CrowdinApi {
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.getMany
+     */
+    listGroups(options?: ProjectsGroupsModel.ListGroupsOptions): Promise<ResponseList<ProjectsGroupsModel.Group>>;
+    /**
      * @param parentId parent group identifier
      * @param offset starting offset in the collection (default 0)
      * @param userId get user own projects
      * @param limit maximum number of items to retrieve (default 25)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.getMany
      */
     listGroups(
@@ -16,10 +21,6 @@ export class ProjectsGroups extends CrowdinApi {
         userId?: number,
         limit?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Group>>;
-    /**
-     * @param options optional options for the request
-     */
-    listGroups(options?: ProjectsGroupsModel.ListGroupsOptions): Promise<ResponseList<ProjectsGroupsModel.Group>>;
     listGroups(
         options?: number | ProjectsGroupsModel.ListGroupsOptions,
         deprecatedOffset?: number,
@@ -79,11 +80,18 @@ export class ProjectsGroups extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.getMany
+     */
+    listProjects(
+        options?: ProjectsGroupsModel.ListProjectsOptions,
+    ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
+    /**
      * @param groupId group identifier
      * @param hasManagerAccess projects with manager access (default 0)
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.getMany
      */
     listProjects(
@@ -91,12 +99,6 @@ export class ProjectsGroups extends CrowdinApi {
         hasManagerAccess?: BooleanInt,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
-    /**
-     * @param options optional options for the request
-     */
-    listProjects(
-        options?: ProjectsGroupsModel.ListProjectsOptions,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
     listProjects(
         options?: number | ProjectsGroupsModel.ListProjectsOptions,

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -1,4 +1,12 @@
-import { BooleanInt, CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    BooleanInt,
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 import { LanguagesModel } from '../languages';
 
 export class ProjectsGroups extends CrowdinApi {
@@ -34,7 +42,7 @@ export class ProjectsGroups extends CrowdinApi {
                 userId: deprecatedUserId,
                 limit: deprecatedLimit,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/groups`;
         url = this.addQueryParam(url, 'parentId', options.parentId);
@@ -113,7 +121,7 @@ export class ProjectsGroups extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -21,12 +21,12 @@ export class ProjectsGroups extends CrowdinApi {
      */
     listGroups(options?: ProjectsGroupsModel.ListGroupsOptions): Promise<ResponseList<ProjectsGroupsModel.Group>>;
     listGroups(
-        options: number | ProjectsGroupsModel.ListGroupsOptions = {},
+        options?: number | ProjectsGroupsModel.ListGroupsOptions,
         deprecatedOffset?: number,
         deprecatedUserId?: number,
         deprecatedLimit?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Group>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 parentId: options,
                 offset: deprecatedOffset,
@@ -99,12 +99,12 @@ export class ProjectsGroups extends CrowdinApi {
         options?: ProjectsGroupsModel.ListProjectsOptions,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
     listProjects(
-        options: number | ProjectsGroupsModel.ListProjectsOptions = {},
+        options?: number | ProjectsGroupsModel.ListProjectsOptions,
         deprecatedHasManagerAccess?: BooleanInt,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 groupId: options,
                 hasManagerAccess: deprecatedHasManagerAccess,

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -1,4 +1,4 @@
-import { BooleanInt, CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { BooleanInt, CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 import { LanguagesModel } from '../languages';
 
 export class ProjectsGroups extends CrowdinApi {
@@ -7,6 +7,7 @@ export class ProjectsGroups extends CrowdinApi {
      * @param offset starting offset in the collection (default 0)
      * @param userId get user own projects
      * @param limit maximum number of items to retrieve (default 25)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.groups.getMany
      */
     listGroups(
@@ -14,11 +15,30 @@ export class ProjectsGroups extends CrowdinApi {
         offset?: number,
         userId?: number,
         limit?: number,
+    ): Promise<ResponseList<ProjectsGroupsModel.Group>>;
+    /**
+     * @param options optional options for the request
+     */
+    listGroups(options?: ProjectsGroupsModel.ListGroupsOptions): Promise<ResponseList<ProjectsGroupsModel.Group>>;
+    listGroups(
+        options: number | ProjectsGroupsModel.ListGroupsOptions = {},
+        deprecatedOffset?: number,
+        deprecatedUserId?: number,
+        deprecatedLimit?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Group>> {
+        if (typeof options === 'number') {
+            options = {
+                parentId: options,
+                offset: deprecatedOffset,
+                userId: deprecatedUserId,
+                limit: deprecatedLimit,
+            };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/groups`;
-        url = this.addQueryParam(url, 'parentId', parentId);
-        url = this.addQueryParam(url, 'userId', userId);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'parentId', options.parentId);
+        url = this.addQueryParam(url, 'userId', options.userId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -63,6 +83,7 @@ export class ProjectsGroups extends CrowdinApi {
      * @param hasManagerAccess projects with manager access (default 0)
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.getMany
      */
     listProjects(
@@ -70,11 +91,32 @@ export class ProjectsGroups extends CrowdinApi {
         hasManagerAccess?: BooleanInt,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
+    /**
+     * @param options optional options for the request
+     */
+    listProjects(
+        options?: ProjectsGroupsModel.ListProjectsOptions,
+    ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>>;
+    listProjects(
+        options: number | ProjectsGroupsModel.ListProjectsOptions = {},
+        deprecatedHasManagerAccess?: BooleanInt,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>> {
+        if (typeof options === 'number') {
+            options = {
+                groupId: options,
+                hasManagerAccess: deprecatedHasManagerAccess,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+            };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects`;
-        url = this.addQueryParam(url, 'groupId', groupId);
-        url = this.addQueryParam(url, 'hasManagerAccess', hasManagerAccess);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'groupId', options.groupId);
+        url = this.addQueryParam(url, 'hasManagerAccess', options.hasManagerAccess);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -352,5 +394,15 @@ export namespace ProjectsGroupsModel {
         translatorNewStrings?: boolean;
         managerNewStrings?: boolean;
         managerLanguageCompleted?: boolean;
+    }
+
+    export interface ListGroupsOptions extends PaginationOptions {
+        parentId?: number;
+        userId?: number;
+    }
+
+    export interface ListProjectsOptions extends PaginationOptions {
+        groupId?: number;
+        hasManagerAccess?: BooleanInt;
     }
 }

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -19,10 +19,10 @@ export class Screenshots extends CrowdinApi {
     listScreenshots(projectId: number, options?: PaginationOptions): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
     listScreenshots(
         projectId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -114,10 +114,10 @@ export class Screenshots extends CrowdinApi {
     listScreenshotTags(
         projectId: number,
         screenshotId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Tag>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Screenshots extends CrowdinApi {
     /**
@@ -26,7 +33,7 @@ export class Screenshots extends CrowdinApi {
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/screenshots`;
         return this.getList(url, options.limit, options.offset);
@@ -128,7 +135,7 @@ export class Screenshots extends CrowdinApi {
     ): Promise<ResponseList<ScreenshotsModel.Tag>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;
         return this.getList(url, options.limit, options.offset);

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Screenshots extends CrowdinApi {
     /**
@@ -11,9 +11,23 @@ export class Screenshots extends CrowdinApi {
         projectId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional pagination options
+     */
+    listScreenshots(projectId: number, options?: PaginationOptions): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
+    listScreenshots(
+        projectId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/screenshots`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -91,9 +105,24 @@ export class Screenshots extends CrowdinApi {
         screenshotId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<ScreenshotsModel.Tag>>;
+    listScreenshotTags(
+        projectId: number,
+        screenshotId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<ScreenshotsModel.Tag>>;
+    listScreenshotTags(
+        projectId: number,
+        screenshotId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Tag>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -3,8 +3,15 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.getMany
+     */
+    listScreenshots(projectId: number, options?: PaginationOptions): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.getMany
      */
     listScreenshots(
@@ -12,11 +19,6 @@ export class Screenshots extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional pagination options
-     */
-    listScreenshots(projectId: number, options?: PaginationOptions): Promise<ResponseList<ScreenshotsModel.Screenshot>>;
     listScreenshots(
         projectId: number,
         options?: number | PaginationOptions,
@@ -96,8 +98,20 @@ export class Screenshots extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param screenshotId screenshot identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.getMany
+     */
+    listScreenshotTags(
+        projectId: number,
+        screenshotId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<ScreenshotsModel.Tag>>;
+    /**
+     * @param projectId project identifier
+     * @param screenshotId screenshot identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.screenshots.tags.getMany
      */
     listScreenshotTags(
@@ -105,11 +119,6 @@ export class Screenshots extends CrowdinApi {
         screenshotId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<ScreenshotsModel.Tag>>;
-    listScreenshotTags(
-        projectId: number,
-        screenshotId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<ScreenshotsModel.Tag>>;
     listScreenshotTags(
         projectId: number,

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Screenshots extends CrowdinApi {
     /**
@@ -31,9 +24,8 @@ export class Screenshots extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/screenshots`;
         return this.getList(url, options.limit, options.offset);
@@ -133,9 +125,8 @@ export class Screenshots extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Tag>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;
         return this.getList(url, options.limit, options.offset);

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, DownloadLink, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, DownloadLink, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class SourceFiles extends CrowdinApi {
     /**
@@ -13,10 +13,28 @@ export class SourceFiles extends CrowdinApi {
         name?: string,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<SourceFilesModel.Branch>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional options for the request
+     */
+    listProjectBranches(
+        projectId: number,
+        options?: SourceFilesModel.ListProjectBranchesOptions,
+    ): Promise<ResponseList<SourceFilesModel.Branch>>;
+    listProjectBranches(
+        projectId: number,
+        options: string | SourceFilesModel.ListProjectBranchesOptions = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.Branch>> {
+        if (typeof options === 'string') {
+            options = { name: options, limit: deprecatedLimit, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects/${projectId}/branches`;
-        url = this.addQueryParam(url, 'name', name);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'name', options.name);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -86,28 +104,40 @@ export class SourceFiles extends CrowdinApi {
         filter?: string,
         recursion?: string,
     ): Promise<ResponseList<SourceFilesModel.Directory>>;
-
+    /**
+     * @param projectId project identifier
+     * @param options optional options for the request
+     */
     listProjectDirectories(
         projectId: number,
-        branchIdOrRequest?: number | SourceFilesModel.ListProjectDirectoriesRequest,
-        directoryId?: number,
-        limit?: number,
-        offset?: number,
-        filter?: string,
-        recursion?: string,
+        options: SourceFilesModel.ListProjectDirectoriesRequest,
+    ): Promise<ResponseList<SourceFilesModel.Directory>>;
+    listProjectDirectories(
+        projectId: number,
+        options: number | SourceFilesModel.ListProjectDirectoriesRequest = {},
+        deprecatedDirectoryId?: number,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+        deprecatedFilter?: string,
+        deprecatedRecursion?: string,
     ): Promise<ResponseList<SourceFilesModel.Directory>> {
         let url = `${this.url}/projects/${projectId}/directories`;
-        let request: SourceFilesModel.ListProjectDirectoriesRequest;
-        if (branchIdOrRequest && typeof branchIdOrRequest === 'object') {
-            request = branchIdOrRequest;
-        } else {
-            request = { branchId: branchIdOrRequest, directoryId, limit, offset, recursion, filter };
+        if (typeof options === 'number') {
+            options = {
+                branchId: options,
+                directoryId: deprecatedDirectoryId,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+                recursion: deprecatedRecursion,
+                filter: deprecatedFilter,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'branchId', request.branchId);
-        url = this.addQueryParam(url, 'directoryId', request.directoryId);
-        url = this.addQueryParam(url, 'filter', request.filter);
-        url = this.addQueryParam(url, 'recursion', request.recursion);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'branchId', options.branchId);
+        url = this.addQueryParam(url, 'directoryId', options.directoryId);
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'recursion', options.recursion);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -159,7 +189,6 @@ export class SourceFiles extends CrowdinApi {
     }
 
     /**
-     *
      * @param projectId project identifier
      * @param branchId list branch files (Note! You can either list files for the specified branch (branchId) in the same request)
      * @param directoryId list directory files (Note! You can either list files for the specified directory (directoryId) in the same request)
@@ -178,33 +207,41 @@ export class SourceFiles extends CrowdinApi {
         recursion?: any,
         filter?: string,
     ): Promise<ResponseList<SourceFilesModel.File>>;
-
+    /**
+     * @param projectId project identifier
+     * @param options optional options for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany
+     */
     listProjectFiles(
         projectId: number,
-        request: SourceFilesModel.ListProjectFilesRequest,
+        options?: SourceFilesModel.ListProjectFilesRequest,
     ): Promise<ResponseList<SourceFilesModel.File>>;
-
     listProjectFiles(
         projectId: number,
-        branchIdOrRequest?: number | SourceFilesModel.ListProjectFilesRequest,
-        directoryId?: number,
-        limit?: number,
-        offset?: number,
-        recursion?: any,
-        filter?: string,
+        options: number | SourceFilesModel.ListProjectFilesRequest = {},
+        deprecatedDirectoryId?: number,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+        deprecatedRecursion?: any,
+        deprecatedFilter?: string,
     ): Promise<ResponseList<SourceFilesModel.File>> {
         let url = `${this.url}/projects/${projectId}/files`;
-        let request: SourceFilesModel.ListProjectFilesRequest;
-        if (branchIdOrRequest && typeof branchIdOrRequest === 'object') {
-            request = branchIdOrRequest;
-        } else {
-            request = { branchId: branchIdOrRequest, directoryId, limit, offset, recursion, filter };
+        if (typeof options === 'number') {
+            options = {
+                branchId: options,
+                directoryId: deprecatedDirectoryId,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+                recursion: deprecatedRecursion,
+                filter: deprecatedFilter,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'branchId', request.branchId);
-        url = this.addQueryParam(url, 'directoryId', request.directoryId);
-        url = this.addQueryParam(url, 'recursion', request.recursion);
-        url = this.addQueryParam(url, 'filter', request.filter);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'branchId', options.branchId);
+        url = this.addQueryParam(url, 'directoryId', options.directoryId);
+        url = this.addQueryParam(url, 'recursion', options.recursion);
+        url = this.addQueryParam(url, 'filter', options.filter);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -292,9 +329,24 @@ export class SourceFiles extends CrowdinApi {
         fileId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<SourceFilesModel.FileRevision>>;
+    listFileRevisions(
+        projectId: number,
+        fileId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<SourceFilesModel.FileRevision>>;
+    listFileRevisions(
+        projectId: number,
+        fileId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.FileRevision>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/revisions`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -324,10 +376,24 @@ export class SourceFiles extends CrowdinApi {
         branchId?: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
+    listReviewedSourceFilesBuild(
+        projectId: number,
+        options?: SourceFilesModel.ListReviewedSourceFilesBuildOptions,
+    ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
+    listReviewedSourceFilesBuild(
+        projectId: number,
+        options: number | SourceFilesModel.ListReviewedSourceFilesBuildOptions = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>> {
+        if (typeof options === 'number') {
+            options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects/${projectId}/strings/reviewed-builds`;
-        url = this.addQueryParam(url, 'branchId', branchId);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'branchId', options.branchId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -599,5 +665,13 @@ export namespace SourceFilesModel {
 
     export interface BuildReviewedSourceFilesRequest {
         branchId: number;
+    }
+
+    export interface ListProjectBranchesOptions extends PaginationOptions {
+        name?: string;
+    }
+
+    export interface ListReviewedSourceFilesBuildOptions extends PaginationOptions {
+        branchId?: number;
     }
 }

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -102,7 +102,7 @@ export class SourceFiles extends CrowdinApi {
      */
     listProjectDirectories(
         projectId: number,
-        options?: SourceFilesModel.ListProjectDirectoriesRequest,
+        options?: SourceFilesModel.ListProjectDirectoriesOptions,
     ): Promise<ResponseList<SourceFilesModel.Directory>>;
     /**
      * @param projectId project identifier
@@ -126,7 +126,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.Directory>>;
     listProjectDirectories(
         projectId: number,
-        options?: number | SourceFilesModel.ListProjectDirectoriesRequest,
+        options?: number | SourceFilesModel.ListProjectDirectoriesOptions,
         deprecatedDirectoryId?: number,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
@@ -207,7 +207,7 @@ export class SourceFiles extends CrowdinApi {
      */
     listProjectFiles(
         projectId: number,
-        options?: SourceFilesModel.ListProjectFilesRequest,
+        options?: SourceFilesModel.ListProjectFilesOptions,
     ): Promise<ResponseList<SourceFilesModel.File>>;
     /**
      * @param projectId project identifier
@@ -231,7 +231,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.File>>;
     listProjectFiles(
         projectId: number,
-        options?: number | SourceFilesModel.ListProjectFilesRequest,
+        options?: number | SourceFilesModel.ListProjectFilesOptions,
         deprecatedDirectoryId?: number,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
@@ -484,7 +484,7 @@ export namespace SourceFilesModel {
         HIGH = 'high',
     }
 
-    export interface ListProjectDirectoriesRequest extends PaginationOptions {
+    export interface ListProjectDirectoriesOptions extends PaginationOptions {
         branchId?: number;
         directoryId?: number;
         filter?: string;
@@ -513,7 +513,7 @@ export namespace SourceFilesModel {
         priority?: Priority;
     }
 
-    export interface ListProjectFilesRequest extends PaginationOptions {
+    export interface ListProjectFilesOptions extends PaginationOptions {
         branchId?: number;
         directoryId?: number;
         recursion?: any;

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -24,11 +24,11 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.Branch>>;
     listProjectBranches(
         projectId: number,
-        options: string | SourceFilesModel.ListProjectBranchesOptions = {},
+        options?: string | SourceFilesModel.ListProjectBranchesOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.Branch>> {
-        if (typeof options === 'string') {
+        if (typeof options === 'string' || typeof options === 'undefined') {
             options = { name: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -114,7 +114,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.Directory>>;
     listProjectDirectories(
         projectId: number,
-        options: number | SourceFilesModel.ListProjectDirectoriesRequest = {},
+        options?: number | SourceFilesModel.ListProjectDirectoriesRequest,
         deprecatedDirectoryId?: number,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
@@ -122,7 +122,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedRecursion?: string,
     ): Promise<ResponseList<SourceFilesModel.Directory>> {
         let url = `${this.url}/projects/${projectId}/directories`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -218,7 +218,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.File>>;
     listProjectFiles(
         projectId: number,
-        options: number | SourceFilesModel.ListProjectFilesRequest = {},
+        options?: number | SourceFilesModel.ListProjectFilesRequest,
         deprecatedDirectoryId?: number,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
@@ -226,7 +226,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedFilter?: string,
     ): Promise<ResponseList<SourceFilesModel.File>> {
         let url = `${this.url}/projects/${projectId}/files`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -338,10 +338,10 @@ export class SourceFiles extends CrowdinApi {
     listFileRevisions(
         projectId: number,
         fileId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.FileRevision>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -383,11 +383,11 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
     listReviewedSourceFilesBuild(
         projectId: number,
-        options: number | SourceFilesModel.ListReviewedSourceFilesBuildOptions = {},
+        options?: number | SourceFilesModel.ListReviewedSourceFilesBuildOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -3,9 +3,19 @@ import { CrowdinApi, DownloadLink, PaginationOptions, PatchRequest, ResponseList
 export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.getMany
+     */
+    listProjectBranches(
+        projectId: number,
+        options?: SourceFilesModel.ListProjectBranchesOptions,
+    ): Promise<ResponseList<SourceFilesModel.Branch>>;
+    /**
+     * @param projectId project identifier
      * @param name filter branch by name
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.getMany
      */
     listProjectBranches(
@@ -13,14 +23,6 @@ export class SourceFiles extends CrowdinApi {
         name?: string,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<SourceFilesModel.Branch>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional options for the request
-     */
-    listProjectBranches(
-        projectId: number,
-        options?: SourceFilesModel.ListProjectBranchesOptions,
     ): Promise<ResponseList<SourceFilesModel.Branch>>;
     listProjectBranches(
         projectId: number,
@@ -87,12 +89,22 @@ export class SourceFiles extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.getMany
+     */
+    listProjectDirectories(
+        projectId: number,
+        options?: SourceFilesModel.ListProjectDirectoriesRequest,
+    ): Promise<ResponseList<SourceFilesModel.Directory>>;
+    /**
+     * @param projectId project identifier
      * @param branchId filter directories by branchId
      * @param directoryId filter directories by directoryId
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param filter use to filter directories by name
      * @param recursion use to list directories recursively (works only when directoryId or branchId parameter is specified)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.getMany
      */
     listProjectDirectories(
@@ -103,14 +115,6 @@ export class SourceFiles extends CrowdinApi {
         offset?: number,
         filter?: string,
         recursion?: string,
-    ): Promise<ResponseList<SourceFilesModel.Directory>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional options for the request
-     */
-    listProjectDirectories(
-        projectId: number,
-        options: SourceFilesModel.ListProjectDirectoriesRequest,
     ): Promise<ResponseList<SourceFilesModel.Directory>>;
     listProjectDirectories(
         projectId: number,
@@ -190,12 +194,22 @@ export class SourceFiles extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany
+     */
+    listProjectFiles(
+        projectId: number,
+        options?: SourceFilesModel.ListProjectFilesRequest,
+    ): Promise<ResponseList<SourceFilesModel.File>>;
+    /**
+     * @param projectId project identifier
      * @param branchId list branch files (Note! You can either list files for the specified branch (branchId) in the same request)
      * @param directoryId list directory files (Note! You can either list files for the specified directory (directoryId) in the same request)
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param recursion use to list files recursively
      * @param filter use to filter files by name
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany
      */
     listProjectFiles(
@@ -206,15 +220,6 @@ export class SourceFiles extends CrowdinApi {
         offset?: number,
         recursion?: any,
         filter?: string,
-    ): Promise<ResponseList<SourceFilesModel.File>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional options for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany
-     */
-    listProjectFiles(
-        projectId: number,
-        options?: SourceFilesModel.ListProjectFilesRequest,
     ): Promise<ResponseList<SourceFilesModel.File>>;
     listProjectFiles(
         projectId: number,
@@ -320,8 +325,20 @@ export class SourceFiles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param fileId file identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.revisions.getMany
+     */
+    listFileRevisions(
+        projectId: number,
+        fileId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<SourceFilesModel.FileRevision>>;
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.revisions.getMany
      */
     listFileRevisions(
@@ -329,11 +346,6 @@ export class SourceFiles extends CrowdinApi {
         fileId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<SourceFilesModel.FileRevision>>;
-    listFileRevisions(
-        projectId: number,
-        fileId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<SourceFilesModel.FileRevision>>;
     listFileRevisions(
         projectId: number,
@@ -366,9 +378,19 @@ export class SourceFiles extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.getMany
+     */
+    listReviewedSourceFilesBuild(
+        projectId: number,
+        options?: SourceFilesModel.ListReviewedSourceFilesBuildOptions,
+    ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
+    /**
+     * @param projectId project identifier
      * @param branchId filter builds by branchId
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.reviewed-builds.getMany
      */
     listReviewedSourceFilesBuild(
@@ -376,10 +398,6 @@ export class SourceFiles extends CrowdinApi {
         branchId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
-    listReviewedSourceFilesBuild(
-        projectId: number,
-        options?: SourceFilesModel.ListReviewedSourceFilesBuildOptions,
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>>;
     listReviewedSourceFilesBuild(
         projectId: number,
@@ -458,11 +476,9 @@ export namespace SourceFilesModel {
         HIGH = 'high',
     }
 
-    export interface ListProjectDirectoriesRequest {
+    export interface ListProjectDirectoriesRequest extends PaginationOptions {
         branchId?: number;
         directoryId?: number;
-        limit?: number;
-        offset?: number;
         filter?: string;
         recursion?: string;
     }
@@ -489,11 +505,9 @@ export namespace SourceFilesModel {
         priority?: Priority;
     }
 
-    export interface ListProjectFilesRequest {
+    export interface ListProjectFilesRequest extends PaginationOptions {
         branchId?: number;
         directoryId?: number;
-        limit?: number;
-        offset?: number;
         recursion?: any;
         filter?: string;
     }

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -1,4 +1,12 @@
-import { CrowdinApi, DownloadLink, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    DownloadLink,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class SourceFiles extends CrowdinApi {
     /**
@@ -32,7 +40,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.Branch>> {
         if (typeof options === 'string' || typeof options === 'undefined') {
             options = { name: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/branches`;
         url = this.addQueryParam(url, 'name', options.name);
@@ -135,7 +143,7 @@ export class SourceFiles extends CrowdinApi {
                 recursion: deprecatedRecursion,
                 filter: deprecatedFilter,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'branchId', options.branchId);
         url = this.addQueryParam(url, 'directoryId', options.directoryId);
@@ -240,7 +248,7 @@ export class SourceFiles extends CrowdinApi {
                 recursion: deprecatedRecursion,
                 filter: deprecatedFilter,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'branchId', options.branchId);
         url = this.addQueryParam(url, 'directoryId', options.directoryId);
@@ -355,7 +363,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.FileRevision>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/revisions`;
         return this.getList(url, options.limit, options.offset);
@@ -407,7 +415,7 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/strings/reviewed-builds`;
         url = this.addQueryParam(url, 'branchId', options.branchId);

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -1,7 +1,8 @@
 import {
     CrowdinApi,
     DownloadLink,
-    emitDeprecationWarning,
+    isOptionalNumber,
+    isOptionalString,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -38,9 +39,8 @@ export class SourceFiles extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.Branch>> {
-        if (typeof options === 'string' || typeof options === 'undefined') {
+        if (isOptionalString(options)) {
             options = { name: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/branches`;
         url = this.addQueryParam(url, 'name', options.name);
@@ -134,7 +134,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedRecursion?: string,
     ): Promise<ResponseList<SourceFilesModel.Directory>> {
         let url = `${this.url}/projects/${projectId}/directories`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -143,7 +143,6 @@ export class SourceFiles extends CrowdinApi {
                 recursion: deprecatedRecursion,
                 filter: deprecatedFilter,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'branchId', options.branchId);
         url = this.addQueryParam(url, 'directoryId', options.directoryId);
@@ -239,7 +238,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedFilter?: string,
     ): Promise<ResponseList<SourceFilesModel.File>> {
         let url = `${this.url}/projects/${projectId}/files`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -248,7 +247,6 @@ export class SourceFiles extends CrowdinApi {
                 recursion: deprecatedRecursion,
                 filter: deprecatedFilter,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'branchId', options.branchId);
         url = this.addQueryParam(url, 'directoryId', options.directoryId);
@@ -361,9 +359,8 @@ export class SourceFiles extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.FileRevision>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/revisions`;
         return this.getList(url, options.limit, options.offset);
@@ -413,9 +410,8 @@ export class SourceFiles extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/strings/reviewed-builds`;
         url = this.addQueryParam(url, 'branchId', options.branchId);

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -1,6 +1,15 @@
-import { BooleanInt, CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { BooleanInt, CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class SourceStrings extends CrowdinApi {
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.getMany
+     */
+    listProjectStrings(
+        projectId: number,
+        options?: SourceStringsModel.ListProjectStringsOptions,
+    ): Promise<ResponseList<SourceStringsModel.String>>;
     /**
      * @param projectId project identifier
      * @param fileId file identifier
@@ -13,7 +22,7 @@ export class SourceStrings extends CrowdinApi {
      * @param croql filter strings by CroQL (Can't be used with `labelIds`, `filter` or `scope` in same request)
      * @param branchId filter by branch identifier
      * @param directoryId filter by directory identifier
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.getMany
      */
     listProjectStrings(
@@ -29,17 +38,9 @@ export class SourceStrings extends CrowdinApi {
         branchId?: number,
         directoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     */
     listProjectStrings(
         projectId: number,
-        options: SourceStringsModel.ListProjectStringsRequest,
-    ): Promise<ResponseList<SourceStringsModel.String>>;
-    listProjectStrings(
-        projectId: number,
-        options?: number | SourceStringsModel.ListProjectStringsRequest,
+        options?: number | SourceStringsModel.ListProjectStringsOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
         deprecatedFilter?: string,
@@ -127,10 +128,8 @@ export class SourceStrings extends CrowdinApi {
 }
 
 export namespace SourceStringsModel {
-    export interface ListProjectStringsRequest {
+    export interface ListProjectStringsOptions extends PaginationOptions {
         fileId?: number;
-        limit?: number;
-        offset?: number;
         filter?: string;
         denormalizePlaceholders?: BooleanInt;
         labelIds?: string;

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -39,7 +39,7 @@ export class SourceStrings extends CrowdinApi {
     ): Promise<ResponseList<SourceStringsModel.String>>;
     listProjectStrings(
         projectId: number,
-        options: number | SourceStringsModel.ListProjectStringsRequest = {},
+        options?: number | SourceStringsModel.ListProjectStringsRequest,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
         deprecatedFilter?: string,
@@ -51,7 +51,7 @@ export class SourceStrings extends CrowdinApi {
         deprecatedDirectoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>> {
         let url = `${this.url}/projects/${projectId}/strings`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 fileId: options,
                 limit: deprecatedLimit,

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -13,6 +13,7 @@ export class SourceStrings extends CrowdinApi {
      * @param croql filter strings by CroQL (Can't be used with `labelIds`, `filter` or `scope` in same request)
      * @param branchId filter by branch identifier
      * @param directoryId filter by directory identifier
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.getMany
      */
     listProjectStrings(
@@ -28,52 +29,52 @@ export class SourceStrings extends CrowdinApi {
         branchId?: number,
         directoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>>;
-
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     */
     listProjectStrings(
         projectId: number,
-        request: SourceStringsModel.ListProjectStringsRequest,
+        options: SourceStringsModel.ListProjectStringsRequest,
     ): Promise<ResponseList<SourceStringsModel.String>>;
-
     listProjectStrings(
         projectId: number,
-        fileIdOrRequest?: number | SourceStringsModel.ListProjectStringsRequest,
-        limit?: number,
-        offset?: number,
-        filter?: string,
-        denormalizePlaceholders?: BooleanInt,
-        labelIds?: string,
-        scope?: SourceStringsModel.Scope,
-        croql?: string,
-        branchId?: number,
-        directoryId?: number,
+        options: number | SourceStringsModel.ListProjectStringsRequest = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+        deprecatedFilter?: string,
+        deprecatedDenormalizePlaceholders?: BooleanInt,
+        deprecatedLabelIds?: string,
+        deprecatedScope?: SourceStringsModel.Scope,
+        deprecatedCroql?: string,
+        deprecatedBranchId?: number,
+        deprecatedDirectoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>> {
         let url = `${this.url}/projects/${projectId}/strings`;
-        let request: SourceStringsModel.ListProjectStringsRequest;
-        if (fileIdOrRequest && typeof fileIdOrRequest === 'object') {
-            request = fileIdOrRequest;
-        } else {
-            request = {
-                fileId: fileIdOrRequest,
-                limit,
-                offset,
-                filter,
-                denormalizePlaceholders,
-                labelIds,
-                scope,
-                croql,
-                branchId,
-                directoryId,
+        if (typeof options === 'number') {
+            options = {
+                fileId: options,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+                filter: deprecatedFilter,
+                denormalizePlaceholders: deprecatedDenormalizePlaceholders,
+                labelIds: deprecatedLabelIds,
+                scope: deprecatedScope,
+                croql: deprecatedCroql,
+                branchId: deprecatedBranchId,
+                directoryId: deprecatedDirectoryId,
             };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'fileId', request.fileId);
-        url = this.addQueryParam(url, 'filter', request.filter);
-        url = this.addQueryParam(url, 'denormalizePlaceholders', request.denormalizePlaceholders);
-        url = this.addQueryParam(url, 'labelIds', request.labelIds);
-        url = this.addQueryParam(url, 'scope', request.scope);
-        url = this.addQueryParam(url, 'croql', request.croql);
-        url = this.addQueryParam(url, 'branchId', request.branchId);
-        url = this.addQueryParam(url, 'directoryId', request.directoryId);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'fileId', options.fileId);
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'denormalizePlaceholders', options.denormalizePlaceholders);
+        url = this.addQueryParam(url, 'labelIds', options.labelIds);
+        url = this.addQueryParam(url, 'scope', options.scope);
+        url = this.addQueryParam(url, 'croql', options.croql);
+        url = this.addQueryParam(url, 'branchId', options.branchId);
+        url = this.addQueryParam(url, 'directoryId', options.directoryId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -1,7 +1,7 @@
 import {
     BooleanInt,
     CrowdinApi,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -60,7 +60,7 @@ export class SourceStrings extends CrowdinApi {
         deprecatedDirectoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>> {
         let url = `${this.url}/projects/${projectId}/strings`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 fileId: options,
                 limit: deprecatedLimit,
@@ -73,7 +73,6 @@ export class SourceStrings extends CrowdinApi {
                 branchId: deprecatedBranchId,
                 directoryId: deprecatedDirectoryId,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'fileId', options.fileId);
         url = this.addQueryParam(url, 'filter', options.filter);

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -1,4 +1,12 @@
-import { BooleanInt, CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    BooleanInt,
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class SourceStrings extends CrowdinApi {
     /**
@@ -65,7 +73,7 @@ export class SourceStrings extends CrowdinApi {
                 branchId: deprecatedBranchId,
                 directoryId: deprecatedDirectoryId,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'fileId', options.fileId);
         url = this.addQueryParam(url, 'filter', options.filter);

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -31,14 +31,14 @@ export class StringComments extends CrowdinApi {
 
     listStringComments(
         projectId: number,
-        options: number | StringCommentsModel.ListStringCommentsRequest = {},
+        options?: number | StringCommentsModel.ListStringCommentsRequest,
         deprecatedType?: StringCommentsModel.Type,
         deprecatedTargetLanguageId?: string,
         deprecatedIssueType?: StringCommentsModel.IssueType,
         deprecatedIssueStatus?: StringCommentsModel.IssueStatus,
     ): Promise<ResponseList<StringCommentsModel.StringComment>> {
         let url = `${this.url}/projects/${projectId}/comments`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 stringId: options,
                 type: deprecatedType,

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class StringComments extends CrowdinApi {
     /**
@@ -46,7 +53,7 @@ export class StringComments extends CrowdinApi {
                 issueStatus: deprecatedIssueStatus,
                 issueType: deprecatedIssueType,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'type', options.type);

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -15,7 +15,7 @@ export class StringComments extends CrowdinApi {
      */
     listStringComments(
         projectId: number,
-        options?: StringCommentsModel.ListStringCommentsRequest,
+        options?: StringCommentsModel.ListStringCommentsOptions,
     ): Promise<ResponseList<StringCommentsModel.StringComment>>;
     /**
      * @param projectId project identifier
@@ -38,7 +38,7 @@ export class StringComments extends CrowdinApi {
 
     listStringComments(
         projectId: number,
-        options?: number | StringCommentsModel.ListStringCommentsRequest,
+        options?: number | StringCommentsModel.ListStringCommentsOptions,
         deprecatedType?: StringCommentsModel.Type,
         deprecatedTargetLanguageId?: string,
         deprecatedIssueType?: StringCommentsModel.IssueType,
@@ -116,7 +116,7 @@ export class StringComments extends CrowdinApi {
 }
 
 export namespace StringCommentsModel {
-    export interface ListStringCommentsRequest extends PaginationOptions {
+    export interface ListStringCommentsOptions extends PaginationOptions {
         stringId?: number;
         type?: Type;
         targetLanguageId?: string;

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class StringComments extends CrowdinApi {
     /**
@@ -17,7 +17,7 @@ export class StringComments extends CrowdinApi {
      * @param targetLanguageId defines target language id. It can be one target language id or a list of comma-separated ones
      * @param issueType defines issue type. It can be one issue type or a list of comma-separated ones
      * @param issueStatus defines issue resolution status
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.getMany
      */
     listStringComments(
@@ -109,10 +109,8 @@ export class StringComments extends CrowdinApi {
 }
 
 export namespace StringCommentsModel {
-    export interface ListStringCommentsRequest {
+    export interface ListStringCommentsRequest extends PaginationOptions {
         stringId?: number;
-        limit?: number;
-        offset?: number;
         type?: Type;
         targetLanguageId?: string;
         issueType?: IssueType;

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class StringComments extends CrowdinApi {
     /**
@@ -45,7 +38,7 @@ export class StringComments extends CrowdinApi {
         deprecatedIssueStatus?: StringCommentsModel.IssueStatus,
     ): Promise<ResponseList<StringCommentsModel.StringComment>> {
         let url = `${this.url}/projects/${projectId}/comments`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 stringId: options,
                 type: deprecatedType,
@@ -53,7 +46,6 @@ export class StringComments extends CrowdinApi {
                 issueStatus: deprecatedIssueStatus,
                 issueType: deprecatedIssueType,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'type', options.type);

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -3,11 +3,21 @@ import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core'
 export class StringComments extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the requesr
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.getMany
+     */
+    listStringComments(
+        projectId: number,
+        options?: StringCommentsModel.ListStringCommentsRequest,
+    ): Promise<ResponseList<StringCommentsModel.StringComment>>;
+    /**
+     * @param projectId project identifier
      * @param stringId string identifier
      * @param type defines string comment type
      * @param targetLanguageId defines target language id. It can be one target language id or a list of comma-separated ones
      * @param issueType defines issue type. It can be one issue type or a list of comma-separated ones
      * @param issueStatus defines issue resolution status
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.comments.getMany
      */
     listStringComments(
@@ -21,30 +31,29 @@ export class StringComments extends CrowdinApi {
 
     listStringComments(
         projectId: number,
-        request?: StringCommentsModel.ListStringCommentsRequest,
-    ): Promise<ResponseList<StringCommentsModel.StringComment>>;
-
-    listStringComments(
-        projectId: number,
-        stringIdOrRequest?: number | StringCommentsModel.ListStringCommentsRequest,
-        type?: StringCommentsModel.Type,
-        targetLanguageId?: string,
-        issueType?: StringCommentsModel.IssueType,
-        issueStatus?: StringCommentsModel.IssueStatus,
+        options: number | StringCommentsModel.ListStringCommentsRequest = {},
+        deprecatedType?: StringCommentsModel.Type,
+        deprecatedTargetLanguageId?: string,
+        deprecatedIssueType?: StringCommentsModel.IssueType,
+        deprecatedIssueStatus?: StringCommentsModel.IssueStatus,
     ): Promise<ResponseList<StringCommentsModel.StringComment>> {
         let url = `${this.url}/projects/${projectId}/comments`;
-        let request: StringCommentsModel.ListStringCommentsRequest;
-        if (stringIdOrRequest && typeof stringIdOrRequest === 'object') {
-            request = stringIdOrRequest;
-        } else {
-            request = { stringId: stringIdOrRequest, type, targetLanguageId, issueStatus, issueType };
+        if (typeof options === 'number') {
+            options = {
+                stringId: options,
+                type: deprecatedType,
+                targetLanguageId: deprecatedTargetLanguageId,
+                issueStatus: deprecatedIssueStatus,
+                issueType: deprecatedIssueType,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'stringId', request.stringId);
-        url = this.addQueryParam(url, 'type', request.type);
-        url = this.addQueryParam(url, 'targetLanguageId', request.targetLanguageId);
-        url = this.addQueryParam(url, 'issueType', request.issueType);
-        url = this.addQueryParam(url, 'issueStatus', request.issueStatus);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'stringId', options.stringId);
+        url = this.addQueryParam(url, 'type', options.type);
+        url = this.addQueryParam(url, 'targetLanguageId', options.targetLanguageId);
+        url = this.addQueryParam(url, 'issueType', options.issueType);
+        url = this.addQueryParam(url, 'issueStatus', options.issueStatus);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -3,13 +3,22 @@ import { BooleanInt, CrowdinApi, PaginationOptions, ResponseList, ResponseObject
 export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.getMany
+     */
+    listTranslationApprovals(
+        projectId: number,
+        options?: StringTranslationsModel.ListTranslationApprovalsRequest,
+    ): Promise<ResponseList<StringTranslationsModel.Approval>>;
+    /**
+     * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier
      * @param translationId translation identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param fileId file identifier
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.getMany
      */
     listTranslationApprovals(
@@ -20,14 +29,6 @@ export class StringTranslations extends CrowdinApi {
         limit?: number,
         offset?: number,
         fileId?: number,
-    ): Promise<ResponseList<StringTranslationsModel.Approval>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     */
-    listTranslationApprovals(
-        projectId: number,
-        options?: StringTranslationsModel.ListTranslationApprovalsRequest,
     ): Promise<ResponseList<StringTranslationsModel.Approval>>;
     listTranslationApprovals(
         projectId: number,
@@ -93,6 +94,23 @@ export class StringTranslations extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param languageId language identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.translations.getMany
+     */
+    listLanguageTranslations(
+        projectId: number,
+        languageId: string,
+        options?: StringTranslationsModel.ListLanguageTranslationsOptions,
+    ): Promise<
+        ResponseList<
+            | StringTranslationsModel.PlainLanguageTranslation
+            | StringTranslationsModel.PluralLanguageTranslation
+            | StringTranslationsModel.IcuLanguageTranslation
+        >
+    >;
+    /**
+     * @param projectId project identifier
+     * @param languageId language identifier
      * @param stringIds filter translations by stringIds
      * @param fileId filter translations by fileId
      * @param limit maximum number of items to retrieve (default 25)
@@ -100,7 +118,7 @@ export class StringTranslations extends CrowdinApi {
      * @param labelIds filter translations by fileId
      * @param denormalizePlaceholders enable denormalize placeholders
      * @param croql filter translations by CroQL (Can't be used with `stringIds`, `labelIds` or `fileId` in same request)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.translations.getMany
      */
     listLanguageTranslations(
@@ -120,27 +138,10 @@ export class StringTranslations extends CrowdinApi {
             | StringTranslationsModel.IcuLanguageTranslation
         >
     >;
-    /**
-     *
-     * @param projectId project identifier
-     * @param languageId language identifier
-     * @param options optional parameters for the request
-     */
     listLanguageTranslations(
         projectId: number,
         languageId: string,
-        options?: StringTranslationsModel.ListLanguageTranslationsRequest,
-    ): Promise<
-        ResponseList<
-            | StringTranslationsModel.PlainLanguageTranslation
-            | StringTranslationsModel.PluralLanguageTranslation
-            | StringTranslationsModel.IcuLanguageTranslation
-        >
-    >;
-    listLanguageTranslations(
-        projectId: number,
-        languageId: string,
-        options?: string | StringTranslationsModel.ListLanguageTranslationsRequest,
+        options?: string | StringTranslationsModel.ListLanguageTranslationsOptions,
         fileId?: number,
         limit?: number,
         offset?: number,
@@ -179,10 +180,23 @@ export class StringTranslations extends CrowdinApi {
      * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.getMany
+     */
+    listStringTranslations(
+        projectId: number,
+        stringId: number,
+        languageId: string,
+        options?: StringTranslationsModel.ListStringTranslationsOptions,
+    ): Promise<ResponseList<StringTranslationsModel.StringTranslation>>;
+    /**
+     * @param projectId project identifier
+     * @param stringId string identifier
+     * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param denormalizePlaceholders enable denormalize placeholders
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.getMany
      */
     listStringTranslations(
@@ -192,18 +206,6 @@ export class StringTranslations extends CrowdinApi {
         limit?: number,
         offset?: number,
         denormalizePlaceholders?: BooleanInt,
-    ): Promise<ResponseList<StringTranslationsModel.StringTranslation>>;
-    /**
-     * @param projectId project identifier
-     * @param stringId string identifier
-     * @param languageId language identifier
-     * @param options optional parameters for the request
-     */
-    listStringTranslations(
-        projectId: number,
-        stringId: number,
-        languageId: string,
-        options?: StringTranslationsModel.ListStringTranslationsOptions,
     ): Promise<ResponseList<StringTranslationsModel.StringTranslation>>;
     listStringTranslations(
         projectId: number,
@@ -292,11 +294,21 @@ export class StringTranslations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.getMany
+     */
+    listTranslationVotes(
+        projectId: number,
+        options?: StringTranslationsModel.ListTranslationVotesRequest,
+    ): Promise<ResponseList<StringTranslationsModel.Vote>>;
+    /**
+     * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier
      * @param translationId translation identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.votes.getMany
      */
     listTranslationVotes(
@@ -306,14 +318,6 @@ export class StringTranslations extends CrowdinApi {
         translationId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<StringTranslationsModel.Vote>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     */
-    listTranslationVotes(
-        projectId: number,
-        options?: StringTranslationsModel.ListTranslationVotesRequest,
     ): Promise<ResponseList<StringTranslationsModel.Vote>>;
     listTranslationVotes(
         projectId: number,
@@ -375,12 +379,10 @@ export class StringTranslations extends CrowdinApi {
 }
 
 export namespace StringTranslationsModel {
-    export interface ListTranslationApprovalsRequest {
+    export interface ListTranslationApprovalsRequest extends PaginationOptions {
         stringId?: number;
         languageId?: string;
         translationId?: number;
-        limit?: number;
-        offset?: number;
         fileId?: number;
     }
 
@@ -407,11 +409,9 @@ export namespace StringTranslationsModel {
         createdAt: string;
     }
 
-    export interface ListLanguageTranslationsRequest {
+    export interface ListLanguageTranslationsOptions extends PaginationOptions {
         stringIds?: string;
         fileId?: number;
-        limit?: number;
-        offset?: number;
         labelIds?: string;
         denormalizePlaceholders?: BooleanInt;
         croql?: string;

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -1,4 +1,4 @@
-import { BooleanInt, CrowdinApi, ResponseList, ResponseObject } from '../core';
+import { BooleanInt, CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 export class StringTranslations extends CrowdinApi {
     /**
@@ -9,6 +9,7 @@ export class StringTranslations extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param fileId file identifier
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.approvals.getMany
      */
     listTranslationApprovals(
@@ -20,28 +21,40 @@ export class StringTranslations extends CrowdinApi {
         offset?: number,
         fileId?: number,
     ): Promise<ResponseList<StringTranslationsModel.Approval>>;
-
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     */
     listTranslationApprovals(
         projectId: number,
-        stringIdOrRequest?: number | StringTranslationsModel.ListTranslationApprovalsRequest,
-        languageId?: string,
-        translationId?: number,
-        limit?: number,
-        offset?: number,
-        fileId?: number,
+        options?: StringTranslationsModel.ListTranslationApprovalsRequest,
+    ): Promise<ResponseList<StringTranslationsModel.Approval>>;
+    listTranslationApprovals(
+        projectId: number,
+        options: number | StringTranslationsModel.ListTranslationApprovalsRequest = {},
+        deprecatedLanguageId?: string,
+        deprecatedTranslationId?: number,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
+        deprecatedFileId?: number,
     ): Promise<ResponseList<StringTranslationsModel.Approval>> {
         let url = `${this.url}/projects/${projectId}/approvals`;
-        let request: StringTranslationsModel.ListTranslationApprovalsRequest;
-        if (stringIdOrRequest && typeof stringIdOrRequest === 'object') {
-            request = stringIdOrRequest;
-        } else {
-            request = { stringId: stringIdOrRequest, languageId, translationId, limit, offset, fileId };
+        if (typeof options === 'number') {
+            options = {
+                stringId: options,
+                languageId: deprecatedLanguageId,
+                translationId: deprecatedTranslationId,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+                fileId: deprecatedFileId,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'stringId', request.stringId);
-        url = this.addQueryParam(url, 'languageId', request.languageId);
-        url = this.addQueryParam(url, 'translationId', request.translationId);
-        url = this.addQueryParam(url, 'fileId', request.fileId);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'stringId', options.stringId);
+        url = this.addQueryParam(url, 'languageId', options.languageId);
+        url = this.addQueryParam(url, 'translationId', options.translationId);
+        url = this.addQueryParam(url, 'fileId', options.fileId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -87,6 +100,7 @@ export class StringTranslations extends CrowdinApi {
      * @param labelIds filter translations by fileId
      * @param denormalizePlaceholders enable denormalize placeholders
      * @param croql filter translations by CroQL (Can't be used with `stringIds`, `labelIds` or `fileId` in same request)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.translations.getMany
      */
     listLanguageTranslations(
@@ -106,11 +120,27 @@ export class StringTranslations extends CrowdinApi {
             | StringTranslationsModel.IcuLanguageTranslation
         >
     >;
-
+    /**
+     *
+     * @param projectId project identifier
+     * @param languageId language identifier
+     * @param options optional parameters for the request
+     */
     listLanguageTranslations(
         projectId: number,
         languageId: string,
-        stringIdsOrRequest?: string | StringTranslationsModel.ListLanguageTranslationsRequest,
+        options?: StringTranslationsModel.ListLanguageTranslationsRequest,
+    ): Promise<
+        ResponseList<
+            | StringTranslationsModel.PlainLanguageTranslation
+            | StringTranslationsModel.PluralLanguageTranslation
+            | StringTranslationsModel.IcuLanguageTranslation
+        >
+    >;
+    listLanguageTranslations(
+        projectId: number,
+        languageId: string,
+        options: string | StringTranslationsModel.ListLanguageTranslationsRequest = {},
         fileId?: number,
         limit?: number,
         offset?: number,
@@ -125,12 +155,9 @@ export class StringTranslations extends CrowdinApi {
         >
     > {
         let url = `${this.url}/projects/${projectId}/languages/${languageId}/translations`;
-        let request: StringTranslationsModel.ListLanguageTranslationsRequest;
-        if (stringIdsOrRequest && typeof stringIdsOrRequest === 'object') {
-            request = stringIdsOrRequest;
-        } else {
-            request = {
-                stringIds: stringIdsOrRequest,
+        if (typeof options === 'string') {
+            options = {
+                stringIds: options,
                 fileId,
                 limit,
                 offset,
@@ -138,13 +165,14 @@ export class StringTranslations extends CrowdinApi {
                 denormalizePlaceholders,
                 croql,
             };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'stringIds', request.stringIds);
-        url = this.addQueryParam(url, 'fileId', request.fileId);
-        url = this.addQueryParam(url, 'labelIds', request.labelIds);
-        url = this.addQueryParam(url, 'denormalizePlaceholders', request.denormalizePlaceholders);
-        url = this.addQueryParam(url, 'croql', request.croql);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'stringIds', options.stringIds);
+        url = this.addQueryParam(url, 'fileId', options.fileId);
+        url = this.addQueryParam(url, 'labelIds', options.labelIds);
+        url = this.addQueryParam(url, 'denormalizePlaceholders', options.denormalizePlaceholders);
+        url = this.addQueryParam(url, 'croql', options.croql);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -154,6 +182,7 @@ export class StringTranslations extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param denormalizePlaceholders enable denormalize placeholders
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.getMany
      */
     listStringTranslations(
@@ -163,12 +192,40 @@ export class StringTranslations extends CrowdinApi {
         limit?: number,
         offset?: number,
         denormalizePlaceholders?: BooleanInt,
+    ): Promise<ResponseList<StringTranslationsModel.StringTranslation>>;
+    /**
+     * @param projectId project identifier
+     * @param stringId string identifier
+     * @param languageId language identifier
+     * @param options optional parameters for the request
+     */
+    listStringTranslations(
+        projectId: number,
+        stringId: number,
+        languageId: string,
+        options?: StringTranslationsModel.ListStringTranslationsOptions,
+    ): Promise<ResponseList<StringTranslationsModel.StringTranslation>>;
+    listStringTranslations(
+        projectId: number,
+        stringId: number,
+        languageId: string,
+        options: number | StringTranslationsModel.ListStringTranslationsOptions = {},
+        deprecatedOffset?: number,
+        deprecatedDenormalizePlaceholders?: BooleanInt,
     ): Promise<ResponseList<StringTranslationsModel.StringTranslation>> {
+        if (typeof options === 'number') {
+            options = {
+                limit: options,
+                offset: deprecatedOffset,
+                denormalizePlaceholders: deprecatedDenormalizePlaceholders,
+            };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects/${projectId}/translations`;
         url = this.addQueryParam(url, 'stringId', stringId);
         url = this.addQueryParam(url, 'languageId', languageId);
-        url = this.addQueryParam(url, 'denormalizePlaceholders', denormalizePlaceholders);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'denormalizePlaceholders', options.denormalizePlaceholders);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -250,26 +307,37 @@ export class StringTranslations extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<StringTranslationsModel.Vote>>;
-
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     */
     listTranslationVotes(
         projectId: number,
-        stringIdOrRequest?: number | StringTranslationsModel.ListTranslationVotesRequest,
-        languageId?: string,
-        translationId?: number,
-        limit?: number,
-        offset?: number,
+        options?: StringTranslationsModel.ListTranslationVotesRequest,
+    ): Promise<ResponseList<StringTranslationsModel.Vote>>;
+    listTranslationVotes(
+        projectId: number,
+        options: number | StringTranslationsModel.ListTranslationVotesRequest = {},
+        deprecatedLanguageId?: string,
+        deprecatedTranslationId?: number,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<StringTranslationsModel.Vote>> {
         let url = `${this.url}/projects/${projectId}/votes`;
-        let request: StringTranslationsModel.ListTranslationVotesRequest;
-        if (stringIdOrRequest && typeof stringIdOrRequest === 'object') {
-            request = stringIdOrRequest;
-        } else {
-            request = { stringId: stringIdOrRequest, languageId, translationId, limit, offset };
+        if (typeof options === 'number') {
+            options = {
+                stringId: options,
+                languageId: deprecatedLanguageId,
+                translationId: deprecatedTranslationId,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'stringId', request.stringId);
-        url = this.addQueryParam(url, 'languageId', request.languageId);
-        url = this.addQueryParam(url, 'translationId', request.translationId);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'stringId', options.stringId);
+        url = this.addQueryParam(url, 'languageId', options.languageId);
+        url = this.addQueryParam(url, 'translationId', options.translationId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -388,12 +456,10 @@ export namespace StringTranslationsModel {
         pluralCategoryName?: string;
     }
 
-    export interface ListTranslationVotesRequest {
+    export interface ListTranslationVotesRequest extends PaginationOptions {
         stringId?: number;
         languageId?: string;
         translationId?: number;
-        limit?: number;
-        offset?: number;
     }
 
     export interface Vote {
@@ -419,5 +485,9 @@ export namespace StringTranslationsModel {
     export enum Mark {
         UP = 'up',
         DOWN = 'down',
+    }
+
+    export interface ListStringTranslationsOptions extends PaginationOptions {
+        denormalizePlaceholders?: BooleanInt;
     }
 }

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -31,7 +31,7 @@ export class StringTranslations extends CrowdinApi {
     ): Promise<ResponseList<StringTranslationsModel.Approval>>;
     listTranslationApprovals(
         projectId: number,
-        options: number | StringTranslationsModel.ListTranslationApprovalsRequest = {},
+        options?: number | StringTranslationsModel.ListTranslationApprovalsRequest,
         deprecatedLanguageId?: string,
         deprecatedTranslationId?: number,
         deprecatedLimit?: number,
@@ -39,7 +39,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedFileId?: number,
     ): Promise<ResponseList<StringTranslationsModel.Approval>> {
         let url = `${this.url}/projects/${projectId}/approvals`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,
@@ -140,7 +140,7 @@ export class StringTranslations extends CrowdinApi {
     listLanguageTranslations(
         projectId: number,
         languageId: string,
-        options: string | StringTranslationsModel.ListLanguageTranslationsRequest = {},
+        options?: string | StringTranslationsModel.ListLanguageTranslationsRequest,
         fileId?: number,
         limit?: number,
         offset?: number,
@@ -155,7 +155,7 @@ export class StringTranslations extends CrowdinApi {
         >
     > {
         let url = `${this.url}/projects/${projectId}/languages/${languageId}/translations`;
-        if (typeof options === 'string') {
+        if (typeof options === 'string' || typeof options === 'undefined') {
             options = {
                 stringIds: options,
                 fileId,
@@ -209,11 +209,11 @@ export class StringTranslations extends CrowdinApi {
         projectId: number,
         stringId: number,
         languageId: string,
-        options: number | StringTranslationsModel.ListStringTranslationsOptions = {},
+        options?: number | StringTranslationsModel.ListStringTranslationsOptions,
         deprecatedOffset?: number,
         deprecatedDenormalizePlaceholders?: BooleanInt,
     ): Promise<ResponseList<StringTranslationsModel.StringTranslation>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
@@ -317,14 +317,14 @@ export class StringTranslations extends CrowdinApi {
     ): Promise<ResponseList<StringTranslationsModel.Vote>>;
     listTranslationVotes(
         projectId: number,
-        options: number | StringTranslationsModel.ListTranslationVotesRequest = {},
+        options?: number | StringTranslationsModel.ListTranslationVotesRequest,
         deprecatedLanguageId?: string,
         deprecatedTranslationId?: number,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<StringTranslationsModel.Vote>> {
         let url = `${this.url}/projects/${projectId}/votes`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -1,4 +1,11 @@
-import { BooleanInt, CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import {
+    BooleanInt,
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class StringTranslations extends CrowdinApi {
     /**
@@ -49,7 +56,7 @@ export class StringTranslations extends CrowdinApi {
                 offset: deprecatedOffset,
                 fileId: deprecatedFileId,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'languageId', options.languageId);
@@ -166,7 +173,7 @@ export class StringTranslations extends CrowdinApi {
                 denormalizePlaceholders,
                 croql,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringIds', options.stringIds);
         url = this.addQueryParam(url, 'fileId', options.fileId);
@@ -221,7 +228,7 @@ export class StringTranslations extends CrowdinApi {
                 offset: deprecatedOffset,
                 denormalizePlaceholders: deprecatedDenormalizePlaceholders,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/translations`;
         url = this.addQueryParam(url, 'stringId', stringId);
@@ -336,7 +343,7 @@ export class StringTranslations extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'languageId', options.languageId);

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -15,7 +15,7 @@ export class StringTranslations extends CrowdinApi {
      */
     listTranslationApprovals(
         projectId: number,
-        options?: StringTranslationsModel.ListTranslationApprovalsRequest,
+        options?: StringTranslationsModel.ListTranslationApprovalsOptions,
     ): Promise<ResponseList<StringTranslationsModel.Approval>>;
     /**
      * @param projectId project identifier
@@ -39,7 +39,7 @@ export class StringTranslations extends CrowdinApi {
     ): Promise<ResponseList<StringTranslationsModel.Approval>>;
     listTranslationApprovals(
         projectId: number,
-        options?: number | StringTranslationsModel.ListTranslationApprovalsRequest,
+        options?: number | StringTranslationsModel.ListTranslationApprovalsOptions,
         deprecatedLanguageId?: string,
         deprecatedTranslationId?: number,
         deprecatedLimit?: number,
@@ -306,7 +306,7 @@ export class StringTranslations extends CrowdinApi {
      */
     listTranslationVotes(
         projectId: number,
-        options?: StringTranslationsModel.ListTranslationVotesRequest,
+        options?: StringTranslationsModel.ListTranslationVotesOptions,
     ): Promise<ResponseList<StringTranslationsModel.Vote>>;
     /**
      * @param projectId project identifier
@@ -328,7 +328,7 @@ export class StringTranslations extends CrowdinApi {
     ): Promise<ResponseList<StringTranslationsModel.Vote>>;
     listTranslationVotes(
         projectId: number,
-        options?: number | StringTranslationsModel.ListTranslationVotesRequest,
+        options?: number | StringTranslationsModel.ListTranslationVotesOptions,
         deprecatedLanguageId?: string,
         deprecatedTranslationId?: number,
         deprecatedLimit?: number,
@@ -386,7 +386,7 @@ export class StringTranslations extends CrowdinApi {
 }
 
 export namespace StringTranslationsModel {
-    export interface ListTranslationApprovalsRequest extends PaginationOptions {
+    export interface ListTranslationApprovalsOptions extends PaginationOptions {
         stringId?: number;
         languageId?: string;
         translationId?: number;
@@ -463,7 +463,7 @@ export namespace StringTranslationsModel {
         pluralCategoryName?: string;
     }
 
-    export interface ListTranslationVotesRequest extends PaginationOptions {
+    export interface ListTranslationVotesOptions extends PaginationOptions {
         stringId?: number;
         languageId?: string;
         translationId?: number;

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -1,7 +1,8 @@
 import {
     BooleanInt,
     CrowdinApi,
-    emitDeprecationWarning,
+    isOptionalNumber,
+    isOptionalString,
     PaginationOptions,
     ResponseList,
     ResponseObject,
@@ -47,7 +48,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedFileId?: number,
     ): Promise<ResponseList<StringTranslationsModel.Approval>> {
         let url = `${this.url}/projects/${projectId}/approvals`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,
@@ -56,7 +57,6 @@ export class StringTranslations extends CrowdinApi {
                 offset: deprecatedOffset,
                 fileId: deprecatedFileId,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'languageId', options.languageId);
@@ -163,7 +163,7 @@ export class StringTranslations extends CrowdinApi {
         >
     > {
         let url = `${this.url}/projects/${projectId}/languages/${languageId}/translations`;
-        if (typeof options === 'string' || typeof options === 'undefined') {
+        if (isOptionalString(options)) {
             options = {
                 stringIds: options,
                 fileId,
@@ -173,7 +173,6 @@ export class StringTranslations extends CrowdinApi {
                 denormalizePlaceholders,
                 croql,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringIds', options.stringIds);
         url = this.addQueryParam(url, 'fileId', options.fileId);
@@ -222,13 +221,12 @@ export class StringTranslations extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedDenormalizePlaceholders?: BooleanInt,
     ): Promise<ResponseList<StringTranslationsModel.StringTranslation>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
                 denormalizePlaceholders: deprecatedDenormalizePlaceholders,
             };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/translations`;
         url = this.addQueryParam(url, 'stringId', stringId);
@@ -335,7 +333,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<StringTranslationsModel.Vote>> {
         let url = `${this.url}/projects/${projectId}/votes`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,
@@ -343,7 +341,6 @@ export class StringTranslations extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'languageId', options.languageId);

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -108,7 +108,7 @@ export class Tasks extends CrowdinApi {
      * @param options optional parameters for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.getMany
      */
-    listUserTasks(options?: TasksModel.ListUserTasksRequest): Promise<ResponseList<TasksModel.UserTask>>;
+    listUserTasks(options?: TasksModel.ListUserTasksOptions): Promise<ResponseList<TasksModel.UserTask>>;
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
@@ -124,7 +124,7 @@ export class Tasks extends CrowdinApi {
         isArchived?: BooleanInt,
     ): Promise<ResponseList<TasksModel.UserTask>>;
     listUserTasks(
-        options?: number | TasksModel.ListUserTasksRequest,
+        options?: number | TasksModel.ListUserTasksOptions,
         deprecatedOffset?: number,
         deprecatedStatus?: TasksModel.Status,
         deprecatedIsArchived?: BooleanInt,
@@ -191,7 +191,7 @@ export namespace TasksModel {
         updatedAt: string;
     }
 
-    export interface ListUserTasksRequest extends PaginationOptions {
+    export interface ListUserTasksOptions extends PaginationOptions {
         status?: Status;
         isArchived?: BooleanInt;
     }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -12,6 +12,12 @@ import {
 export class Tasks extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.getMany
+     */
+    listTasks(projectId: number, options?: TasksModel.ListTasksOptions): Promise<ResponseList<TasksModel.Task>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param status list tasks with specified statuses. It can be one status or a list of comma-separated status values
@@ -24,12 +30,6 @@ export class Tasks extends CrowdinApi {
         offset?: number,
         status?: TasksModel.Status,
     ): Promise<ResponseList<TasksModel.Task>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.getMany
-     */
-    listTasks(projectId: number, options?: TasksModel.ListTasksOptions): Promise<ResponseList<TasksModel.Task>>;
     listTasks(
         projectId: number,
         options?: number | TasksModel.ListTasksOptions,

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -30,11 +30,11 @@ export class Tasks extends CrowdinApi {
     listTasks(projectId: number, options?: TasksModel.ListTasksOptions): Promise<ResponseList<TasksModel.Task>>;
     listTasks(
         projectId: number,
-        options: number | TasksModel.ListTasksOptions = {},
+        options?: number | TasksModel.ListTasksOptions,
         deprecatedOffset?: number,
         deprecatedStatus?: TasksModel.Status,
     ): Promise<ResponseList<TasksModel.Task>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset, status: deprecatedStatus };
             this.emitDeprecationWarning();
         }
@@ -122,13 +122,13 @@ export class Tasks extends CrowdinApi {
      */
     listUserTasks(options?: TasksModel.ListUserTasksRequest): Promise<ResponseList<TasksModel.UserTask>>;
     listUserTasks(
-        options: number | TasksModel.ListUserTasksRequest = {},
+        options?: number | TasksModel.ListUserTasksRequest,
         deprecatedOffset?: number,
         deprecatedStatus?: TasksModel.Status,
         deprecatedIsArchived?: BooleanInt,
     ): Promise<ResponseList<TasksModel.UserTask>> {
         let url = `${this.url}/user/tasks`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -14,6 +14,7 @@ export class Tasks extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param status list tasks with specified statuses. It can be one status or a list of comma-separated status values
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.tasks.getMany
      */
     listTasks(
@@ -103,12 +104,17 @@ export class Tasks extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.getMany
+     */
+    listUserTasks(options?: TasksModel.ListUserTasksRequest): Promise<ResponseList<TasksModel.UserTask>>;
+    /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param status list tasks with specified statuses. It can be one status or a list of comma-separated status values
      * @param isArchived list archived/not archived tasks for the authorized user. 1 - archived, 0 - not archived
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.getMany
-     * @deprecated Optional parameters should be passed through an object
      */
     listUserTasks(
         limit?: number,
@@ -116,11 +122,6 @@ export class Tasks extends CrowdinApi {
         status?: TasksModel.Status,
         isArchived?: BooleanInt,
     ): Promise<ResponseList<TasksModel.UserTask>>;
-    /**
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.user.tasks.getMany
-     */
-    listUserTasks(options?: TasksModel.ListUserTasksRequest): Promise<ResponseList<TasksModel.UserTask>>;
     listUserTasks(
         options?: number | TasksModel.ListUserTasksRequest,
         deprecatedOffset?: number,
@@ -189,9 +190,7 @@ export namespace TasksModel {
         updatedAt: string;
     }
 
-    export interface ListUserTasksRequest {
-        limit?: number;
-        offset?: number;
+    export interface ListUserTasksRequest extends PaginationOptions {
         status?: Status;
         isArchived?: BooleanInt;
     }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,7 +2,7 @@ import {
     BooleanInt,
     CrowdinApi,
     DownloadLink,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -36,9 +36,8 @@ export class Tasks extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedStatus?: TasksModel.Status,
     ): Promise<ResponseList<TasksModel.Task>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset, status: deprecatedStatus };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/tasks`;
         url = this.addQueryParam(url, 'status', options.status);
@@ -130,14 +129,13 @@ export class Tasks extends CrowdinApi {
         deprecatedIsArchived?: BooleanInt,
     ): Promise<ResponseList<TasksModel.UserTask>> {
         let url = `${this.url}/user/tasks`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
                 status: deprecatedStatus,
                 isArchived: deprecatedIsArchived,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'status', options.status);
         url = this.addQueryParam(url, 'isArchived', options.isArchived);

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,6 +2,7 @@ import {
     BooleanInt,
     CrowdinApi,
     DownloadLink,
+    emitDeprecationWarning,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -37,7 +38,7 @@ export class Tasks extends CrowdinApi {
     ): Promise<ResponseList<TasksModel.Task>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset, status: deprecatedStatus };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/tasks`;
         url = this.addQueryParam(url, 'status', options.status);
@@ -136,7 +137,7 @@ export class Tasks extends CrowdinApi {
                 status: deprecatedStatus,
                 isArchived: deprecatedIsArchived,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'status', options.status);
         url = this.addQueryParam(url, 'isArchived', options.isArchived);

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, Pagination, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, Pagination, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Teams extends CrowdinApi {
     /**
@@ -18,10 +18,24 @@ export class Teams extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
+     * @deprecated Optional parameters should be passed through an object
      */
-    listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>> {
+    listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>>;
+    /**
+     * @param options optional pagination options for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
+     */
+    listTeams(options?: PaginationOptions): Promise<ResponseList<TeamsModel.Team>>;
+    listTeams(
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<TeamsModel.Team>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/teams`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -65,11 +79,28 @@ export class Teams extends CrowdinApi {
      * @param teamId team identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
      */
-    teamMembersList(teamId: number, limit?: number, offset?: number): Promise<ResponseList<TeamsModel.TeamMember>> {
+    teamMembersList(teamId: number, limit?: number, offset?: number): Promise<ResponseList<TeamsModel.TeamMember>>;
+    /**
+     *
+     * @param teamId team identifier
+     * @param options optional pagination options for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
+     */
+    teamMembersList(teamId: number, options?: PaginationOptions): Promise<ResponseList<TeamsModel.TeamMember>>;
+    teamMembersList(
+        teamId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<TeamsModel.TeamMember>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/teams/${teamId}/members`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -1,6 +1,6 @@
 import {
     CrowdinApi,
-    emitDeprecationWarning,
+    isOptionalNumber,
     Pagination,
     PaginationOptions,
     PatchRequest,
@@ -35,9 +35,8 @@ export class Teams extends CrowdinApi {
      */
     listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>>;
     listTeams(options?: number | PaginationOptions, deprecatedOffset?: number): Promise<ResponseList<TeamsModel.Team>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/teams`;
         return this.getList(url, options.limit, options.offset);
@@ -99,9 +98,8 @@ export class Teams extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TeamsModel.TeamMember>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/teams/${teamId}/members`;
         return this.getList(url, options.limit, options.offset);

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -23,17 +23,17 @@ export class Teams extends CrowdinApi {
     }
 
     /**
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
+     */
+    listTeams(options?: PaginationOptions): Promise<ResponseList<TeamsModel.Team>>;
+    /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
      */
     listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>>;
-    /**
-     * @param options optional pagination parameters for the request
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
-     */
-    listTeams(options?: PaginationOptions): Promise<ResponseList<TeamsModel.Team>>;
     listTeams(options?: number | PaginationOptions, deprecatedOffset?: number): Promise<ResponseList<TeamsModel.Team>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
@@ -82,18 +82,18 @@ export class Teams extends CrowdinApi {
 
     /**
      * @param teamId team identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
+     */
+    teamMembersList(teamId: number, options?: PaginationOptions): Promise<ResponseList<TeamsModel.TeamMember>>;
+    /**
+     * @param teamId team identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
      */
     teamMembersList(teamId: number, limit?: number, offset?: number): Promise<ResponseList<TeamsModel.TeamMember>>;
-    /**
-     * @param teamId team identifier
-     * @param options optional pagination parameters for the request
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
-     */
-    teamMembersList(teamId: number, options?: PaginationOptions): Promise<ResponseList<TeamsModel.TeamMember>>;
     teamMembersList(
         teamId: number,
         options?: number | PaginationOptions,

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -17,12 +17,12 @@ export class Teams extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
-     * @deprecated Optional parameters should be passed through an object
      */
     listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>>;
     /**
-     * @param options optional pagination options for the request
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
      */
     listTeams(options?: PaginationOptions): Promise<ResponseList<TeamsModel.Team>>;
@@ -76,14 +76,13 @@ export class Teams extends CrowdinApi {
      * @param teamId team identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
      */
     teamMembersList(teamId: number, limit?: number, offset?: number): Promise<ResponseList<TeamsModel.TeamMember>>;
     /**
-     *
      * @param teamId team identifier
-     * @param options optional pagination options for the request
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.members.getMany
      */
     teamMembersList(teamId: number, options?: PaginationOptions): Promise<ResponseList<TeamsModel.TeamMember>>;

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -1,4 +1,12 @@
-import { CrowdinApi, Pagination, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    Pagination,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Teams extends CrowdinApi {
     /**
@@ -29,7 +37,7 @@ export class Teams extends CrowdinApi {
     listTeams(options?: number | PaginationOptions, deprecatedOffset?: number): Promise<ResponseList<TeamsModel.Team>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/teams`;
         return this.getList(url, options.limit, options.offset);
@@ -93,7 +101,7 @@ export class Teams extends CrowdinApi {
     ): Promise<ResponseList<TeamsModel.TeamMember>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/teams/${teamId}/members`;
         return this.getList(url, options.limit, options.offset);

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -26,11 +26,8 @@ export class Teams extends CrowdinApi {
      * @see https://support.crowdin.com/enterprise/api/#operation/api.teams.getMany
      */
     listTeams(options?: PaginationOptions): Promise<ResponseList<TeamsModel.Team>>;
-    listTeams(
-        options: number | PaginationOptions = {},
-        deprecatedOffset?: number,
-    ): Promise<ResponseList<TeamsModel.Team>> {
-        if (typeof options === 'number') {
+    listTeams(options?: number | PaginationOptions, deprecatedOffset?: number): Promise<ResponseList<TeamsModel.Team>> {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -92,10 +89,10 @@ export class Teams extends CrowdinApi {
     teamMembersList(teamId: number, options?: PaginationOptions): Promise<ResponseList<TeamsModel.TeamMember>>;
     teamMembersList(
         teamId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TeamsModel.TeamMember>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -1,6 +1,7 @@
 import {
     CrowdinApi,
     DownloadLink,
+    emitDeprecationWarning,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -35,7 +36,7 @@ export class TranslationMemory extends CrowdinApi {
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/tms`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -29,11 +29,11 @@ export class TranslationMemory extends CrowdinApi {
         options?: TranslationMemoryModel.ListTMsOptions,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
     listTm(
-        options: number | TranslationMemoryModel.ListTMsOptions = {},
+        options?: number | TranslationMemoryModel.ListTMsOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -1,20 +1,45 @@
-import { CrowdinApi, DownloadLink, PatchRequest, ResponseList, ResponseObject, Status } from '../core';
+import {
+    CrowdinApi,
+    DownloadLink,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+    Status,
+} from '../core';
 
 export class TranslationMemory extends CrowdinApi {
     /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
      */
     listTm(
         groupId?: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
+    /**
+     * @param options optional paramerers for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
+     */
+    listTm(
+        options?: TranslationMemoryModel.ListTMsOptions,
+    ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
+    listTm(
+        options: number | TranslationMemoryModel.ListTMsOptions = {},
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>> {
+        if (typeof options === 'number') {
+            options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/tms`;
-        url = this.addQueryParam(url, 'groupId', groupId);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'groupId', options.groupId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -181,5 +206,9 @@ export namespace TranslationMemoryModel {
 
     export interface Scheme {
         [key: string]: number;
+    }
+
+    export interface ListTMsOptions extends PaginationOptions {
+        groupId?: number;
     }
 }

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -11,6 +11,13 @@ import {
 
 export class TranslationMemory extends CrowdinApi {
     /**
+     * @param options optional paramerers for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
+     */
+    listTm(
+        options?: TranslationMemoryModel.ListTMsOptions,
+    ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
+    /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
@@ -21,13 +28,6 @@ export class TranslationMemory extends CrowdinApi {
         groupId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
-    /**
-     * @param options optional paramerers for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
-     */
-    listTm(
-        options?: TranslationMemoryModel.ListTMsOptions,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>>;
     listTm(
         options?: number | TranslationMemoryModel.ListTMsOptions,

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -13,7 +13,7 @@ export class TranslationMemory extends CrowdinApi {
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.tms.getMany
      */
     listTm(

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -1,7 +1,7 @@
 import {
     CrowdinApi,
     DownloadLink,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     PatchRequest,
     ResponseList,
@@ -34,9 +34,8 @@ export class TranslationMemory extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/tms`;
         url = this.addQueryParam(url, 'groupId', options.groupId);

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -4,9 +4,20 @@ export class TranslationStatus extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param branchId branch identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
+     */
+    getBranchProgress(
+        projectId: number,
+        branchId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param branchId branch identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
      */
     getBranchProgress(
@@ -14,17 +25,6 @@ export class TranslationStatus extends CrowdinApi {
         branchId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
-    /**
-     * @param projectId project identifier
-     * @param branchId branch identifier
-     * @param options optional pagination options for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
-     */
-    getBranchProgress(
-        projectId: number,
-        branchId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
     getBranchProgress(
         projectId: number,
@@ -45,7 +45,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param directoryId directory identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
      */
     getDirectoryProgress(
@@ -57,7 +57,7 @@ export class TranslationStatus extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param directoryId directory identifier
-     * @param options optional pagination options
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
      */
     getDirectoryProgress(
@@ -82,9 +82,20 @@ export class TranslationStatus extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param fileId file identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
+     */
+    getFileProgress(
+        projectId: number,
+        fileId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
      */
     getFileProgress(
@@ -92,17 +103,6 @@ export class TranslationStatus extends CrowdinApi {
         fileId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
-    /**
-     * @param projectId project identifier
-     * @param fileId file identifier
-     * @param options optional pagination options
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
-     */
-    getFileProgress(
-        projectId: number,
-        fileId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
     getFileProgress(
         projectId: number,
@@ -121,9 +121,20 @@ export class TranslationStatus extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param languageId language identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
+     */
+    getLanguageProgress(
+        projectId: number,
+        languageId: string,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.FileProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
      */
     getLanguageProgress(
@@ -131,17 +142,6 @@ export class TranslationStatus extends CrowdinApi {
         languageId: string,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationStatusModel.FileProgress>>;
-    /**
-     * @param projectId project identifier
-     * @param languageId language identifier
-     * @param options optional pagination options
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
-     */
-    getLanguageProgress(
-        projectId: number,
-        languageId: string,
-        options?: PaginationOptions,
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>>;
     getLanguageProgress(
         projectId: number,
@@ -159,10 +159,19 @@ export class TranslationStatus extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
+     */
+    getProjectProgress(
+        projectId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param languageIds language identifier for filter
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
      */
     getProjectProgress(
@@ -170,15 +179,6 @@ export class TranslationStatus extends CrowdinApi {
         limit?: number,
         offset?: number,
         languageIds?: string,
-    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
-     */
-    getProjectProgress(
-        projectId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
     getProjectProgress(
         projectId: number,
@@ -197,12 +197,21 @@ export class TranslationStatus extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
+     */
+    listQaCheckIssues(
+        projectId: number,
+        options?: TranslationStatusModel.ListQaCheckIssuesOptions,
+    ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param category defines the issue category
      * @param validation defines the QA check issue validation type
      * @param languageIds filter progress by languageId
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
      */
     listQaCheckIssues(
@@ -212,15 +221,6 @@ export class TranslationStatus extends CrowdinApi {
         category?: TranslationStatusModel.Category,
         validation?: TranslationStatusModel.Validation,
         languageIds?: string,
-    ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
-     */
-    listQaCheckIssues(
-        projectId: number,
-        options?: TranslationStatusModel.ListQaCheckIssuesOptions,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
     listQaCheckIssues(
         projectId: number,

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, ResponseList } from '../core';
+import { CrowdinApi, PaginationOptions, ResponseList } from '../core';
 
 export class TranslationStatus extends CrowdinApi {
     /**
@@ -6,6 +6,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param branchId branch identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
      */
     getBranchProgress(
@@ -13,9 +14,30 @@ export class TranslationStatus extends CrowdinApi {
         branchId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param branchId branch identifier
+     * @param options optional pagination options for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
+     */
+    getBranchProgress(
+        projectId: number,
+        branchId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    getBranchProgress(
+        projectId: number,
+        branchId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/branches/${branchId}/languages/progress`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -23,6 +45,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param directoryId directory identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
      */
     getDirectoryProgress(
@@ -30,9 +53,30 @@ export class TranslationStatus extends CrowdinApi {
         directoryId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param directoryId directory identifier
+     * @param options optional pagination options
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
+     */
+    getDirectoryProgress(
+        projectId: number,
+        directoryId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    getDirectoryProgress(
+        projectId: number,
+        directoryId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}/languages/progress`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -40,6 +84,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param fileId file identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
      */
     getFileProgress(
@@ -47,9 +92,30 @@ export class TranslationStatus extends CrowdinApi {
         fileId: number,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
+     * @param options optional pagination options
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
+     */
+    getFileProgress(
+        projectId: number,
+        fileId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    getFileProgress(
+        projectId: number,
+        fileId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -57,6 +123,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
      */
     getLanguageProgress(
@@ -64,9 +131,30 @@ export class TranslationStatus extends CrowdinApi {
         languageId: string,
         limit?: number,
         offset?: number,
+    ): Promise<ResponseList<TranslationStatusModel.FileProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param languageId language identifier
+     * @param options optional pagination options
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
+     */
+    getLanguageProgress(
+        projectId: number,
+        languageId: string,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.FileProgress>>;
+    getLanguageProgress(
+        projectId: number,
+        languageId: string,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/languages/${languageId}/progress`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -74,6 +162,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @param languageIds language identifier for filter
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
      */
     getProjectProgress(
@@ -81,10 +170,29 @@ export class TranslationStatus extends CrowdinApi {
         limit?: number,
         offset?: number,
         languageIds?: string,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
+     */
+    getProjectProgress(
+        projectId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    getProjectProgress(
+        projectId: number,
+        options: number | TranslationStatusModel.GetProjectProgressOptions = {},
+        deprecatedOffset?: number,
+        deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset, languageIds: deprecatedLanguageIds };
+            this.emitDeprecationWarning();
+        }
         let url = `${this.url}/projects/${projectId}/languages/progress`;
-        url = this.addQueryParam(url, 'languageIds', languageIds);
-        return this.getList(url, limit, offset);
+        url = this.addQueryParam(url, 'languageIds', options.languageIds);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -94,6 +202,7 @@ export class TranslationStatus extends CrowdinApi {
      * @param category defines the issue category
      * @param validation defines the QA check issue validation type
      * @param languageIds filter progress by languageId
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
      */
     listQaCheckIssues(
@@ -104,25 +213,38 @@ export class TranslationStatus extends CrowdinApi {
         validation?: TranslationStatusModel.Validation,
         languageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.qa-checks.getMany
+     */
     listQaCheckIssues(
         projectId: number,
-        limitOrRequest?: number | TranslationStatusModel.ListQaCheckIssuesRequest,
-        offset?: number,
-        category?: TranslationStatusModel.Category,
-        validation?: TranslationStatusModel.Validation,
-        languageIds?: string,
+        options?: TranslationStatusModel.ListQaCheckIssuesOptions,
+    ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
+    listQaCheckIssues(
+        projectId: number,
+        options: number | TranslationStatusModel.ListQaCheckIssuesOptions = {},
+        deprecatedOffset?: number,
+        deprecatedCategory?: TranslationStatusModel.Category,
+        deprecatedValidation?: TranslationStatusModel.Validation,
+        deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>> {
         let url = `${this.url}/projects/${projectId}/qa-checks`;
-        let request: TranslationStatusModel.ListQaCheckIssuesRequest;
-        if (limitOrRequest && typeof limitOrRequest === 'object') {
-            request = limitOrRequest;
-        } else {
-            request = { limit: limitOrRequest, offset, category, validation, languageIds };
+        if (typeof options === 'number') {
+            options = {
+                limit: options,
+                offset: deprecatedOffset,
+                category: deprecatedCategory,
+                validation: deprecatedValidation,
+                languageIds: deprecatedLanguageIds,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'category', request.category);
-        url = this.addQueryParam(url, 'validation', request.validation);
-        url = this.addQueryParam(url, 'languageIds', request.languageIds);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'category', options.category);
+        url = this.addQueryParam(url, 'validation', options.validation);
+        url = this.addQueryParam(url, 'languageIds', options.languageIds);
+        return this.getList(url, options.limit, options.offset);
     }
 }
 
@@ -205,9 +327,7 @@ export namespace TranslationStatusModel {
         ICU_CHECK = 'icu_check',
     }
 
-    export interface ListQaCheckIssuesRequest {
-        limit?: number;
-        offset?: number;
+    export interface ListQaCheckIssuesOptions extends PaginationOptions {
         category?: Category;
         validation?: Validation;
         languageIds?: string;
@@ -222,5 +342,9 @@ export namespace TranslationStatusModel {
         validationDescription: string;
         pluralId: number;
         text: string;
+    }
+
+    export interface GetProjectProgressOptions extends PaginationOptions {
+        languageIds?: string;
     }
 }

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -43,6 +43,17 @@ export class TranslationStatus extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param directoryId directory identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
+     */
+    getDirectoryProgress(
+        projectId: number,
+        directoryId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
+    /**
+     * @param projectId project identifier
+     * @param directoryId directory identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
      * @deprecated optional parameters should be passed through an object
@@ -53,17 +64,6 @@ export class TranslationStatus extends CrowdinApi {
         directoryId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
-    /**
-     * @param projectId project identifier
-     * @param directoryId directory identifier
-     * @param options optional pagination parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
-     */
-    getDirectoryProgress(
-        projectId: number,
-        directoryId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
     getDirectoryProgress(
         projectId: number,

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PaginationOptions, ResponseList } from '../core';
+import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList } from '../core';
 
 export class TranslationStatus extends CrowdinApi {
     /**
@@ -34,7 +34,7 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/branches/${branchId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -73,7 +73,7 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -112,7 +112,7 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -151,7 +151,7 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/languages/${languageId}/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -188,7 +188,7 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset, languageIds: deprecatedLanguageIds };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/languages/progress`;
         url = this.addQueryParam(url, 'languageIds', options.languageIds);
@@ -239,7 +239,7 @@ export class TranslationStatus extends CrowdinApi {
                 validation: deprecatedValidation,
                 languageIds: deprecatedLanguageIds,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'category', options.category);
         url = this.addQueryParam(url, 'validation', options.validation);

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -29,10 +29,10 @@ export class TranslationStatus extends CrowdinApi {
     getBranchProgress(
         projectId: number,
         branchId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -68,10 +68,10 @@ export class TranslationStatus extends CrowdinApi {
     getDirectoryProgress(
         projectId: number,
         directoryId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -107,10 +107,10 @@ export class TranslationStatus extends CrowdinApi {
     getFileProgress(
         projectId: number,
         fileId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -146,10 +146,10 @@ export class TranslationStatus extends CrowdinApi {
     getLanguageProgress(
         projectId: number,
         languageId: string,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -182,11 +182,11 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>>;
     getProjectProgress(
         projectId: number,
-        options: number | TranslationStatusModel.GetProjectProgressOptions = {},
+        options?: number | TranslationStatusModel.GetProjectProgressOptions,
         deprecatedOffset?: number,
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset, languageIds: deprecatedLanguageIds };
             this.emitDeprecationWarning();
         }
@@ -224,14 +224,14 @@ export class TranslationStatus extends CrowdinApi {
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>>;
     listQaCheckIssues(
         projectId: number,
-        options: number | TranslationStatusModel.ListQaCheckIssuesOptions = {},
+        options?: number | TranslationStatusModel.ListQaCheckIssuesOptions,
         deprecatedOffset?: number,
         deprecatedCategory?: TranslationStatusModel.Category,
         deprecatedValidation?: TranslationStatusModel.Validation,
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>> {
         let url = `${this.url}/projects/${projectId}/qa-checks`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList } from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, ResponseList } from '../core';
 
 export class TranslationStatus extends CrowdinApi {
     /**
@@ -32,9 +32,8 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/branches/${branchId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -71,9 +70,8 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -110,9 +108,8 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -149,9 +146,8 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/languages/${languageId}/progress`;
         return this.getList(url, options.limit, options.offset);
@@ -186,9 +182,8 @@ export class TranslationStatus extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset, languageIds: deprecatedLanguageIds };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/languages/progress`;
         url = this.addQueryParam(url, 'languageIds', options.languageIds);
@@ -231,7 +226,7 @@ export class TranslationStatus extends CrowdinApi {
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>> {
         let url = `${this.url}/projects/${projectId}/qa-checks`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
@@ -239,7 +234,6 @@ export class TranslationStatus extends CrowdinApi {
                 validation: deprecatedValidation,
                 languageIds: deprecatedLanguageIds,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'category', options.category);
         url = this.addQueryParam(url, 'validation', options.validation);

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -89,11 +89,11 @@ export class Translations extends CrowdinApi {
     ): Promise<ResponseList<TranslationsModel.Build>>;
     listProjectBuilds(
         projectId: number,
-        options: number | TranslationsModel.ListProjectBuildsOptions = {},
+        options?: number | TranslationsModel.ListProjectBuildsOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationsModel.Build>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,7 +1,7 @@
 import {
     CrowdinApi,
     DownloadLink,
-    emitDeprecationWarning,
+    isOptionalNumber,
     PaginationOptions,
     ResponseList,
     ResponseObject,
@@ -101,9 +101,8 @@ export class Translations extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationsModel.Build>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/translations/builds`;
         url = this.addQueryParam(url, 'branchId', options.branchId);

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -66,10 +66,19 @@ export class Translations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.getMany
+     */
+    listProjectBuilds(
+        projectId: number,
+        options?: TranslationsModel.ListProjectBuildsOptions,
+    ): Promise<ResponseList<TranslationsModel.Build>>;
+    /**
+     * @param projectId project identifier
      * @param branchId branch identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.getMany
      */
     listProjectBuilds(
@@ -77,15 +86,6 @@ export class Translations extends CrowdinApi {
         branchId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<TranslationsModel.Build>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.builds.getMany
-     */
-    listProjectBuilds(
-        projectId: number,
-        options?: TranslationsModel.ListProjectBuildsOptions,
     ): Promise<ResponseList<TranslationsModel.Build>>;
     listProjectBuilds(
         projectId: number,

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,4 +1,12 @@
-import { CrowdinApi, DownloadLink, PaginationOptions, ResponseList, ResponseObject, Status } from '../core';
+import {
+    CrowdinApi,
+    DownloadLink,
+    emitDeprecationWarning,
+    PaginationOptions,
+    ResponseList,
+    ResponseObject,
+    Status,
+} from '../core';
 
 export class Translations extends CrowdinApi {
     /**
@@ -95,7 +103,7 @@ export class Translations extends CrowdinApi {
     ): Promise<ResponseList<TranslationsModel.Build>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         let url = `${this.url}/projects/${projectId}/translations/builds`;
         url = this.addQueryParam(url, 'branchId', options.branchId);

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 const mimetypes: { [key: string]: string } = {
     '3dml': 'text/vnd.in3d.3dml',
@@ -914,11 +914,25 @@ export class UploadStorage extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
      */
-    listStorages(limit?: number, offset?: number): Promise<ResponseList<UploadStorageModel.Storage>> {
+    listStorages(limit?: number, offset?: number): Promise<ResponseList<UploadStorageModel.Storage>>;
+    /**
+     * @param options optional pagination options for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
+     */
+    listStorages(options?: PaginationOptions): Promise<ResponseList<UploadStorageModel.Storage>>;
+    listStorages(
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<UploadStorageModel.Storage>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/storages`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 const mimetypes: { [key: string]: string } = {
     '3dml': 'text/vnd.in3d.3dml',
@@ -929,7 +929,7 @@ export class UploadStorage extends CrowdinApi {
     ): Promise<ResponseList<UploadStorageModel.Storage>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/storages`;
         return this.getList(url, options.limit, options.offset);

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -912,17 +912,17 @@ const mimetypes: { [key: string]: string } = {
 
 export class UploadStorage extends CrowdinApi {
     /**
-     * @param limit maximum number of items to retrieve (default 25)
-     * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
-     * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
-     */
-    listStorages(limit?: number, offset?: number): Promise<ResponseList<UploadStorageModel.Storage>>;
-    /**
-     * @param options optional pagination options for the request
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
      */
     listStorages(options?: PaginationOptions): Promise<ResponseList<UploadStorageModel.Storage>>;
+    /**
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
+     * @see https://support.crowdin.com/api/v2/#operation/api.storages.getMany
+     */
+    listStorages(limit?: number, offset?: number): Promise<ResponseList<UploadStorageModel.Storage>>;
     listStorages(
         options?: number | PaginationOptions,
         deprecatedOffset?: number,

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -924,10 +924,10 @@ export class UploadStorage extends CrowdinApi {
      */
     listStorages(options?: PaginationOptions): Promise<ResponseList<UploadStorageModel.Storage>>;
     listStorages(
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<UploadStorageModel.Storage>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 const mimetypes: { [key: string]: string } = {
     '3dml': 'text/vnd.in3d.3dml',
@@ -927,9 +927,8 @@ export class UploadStorage extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<UploadStorageModel.Storage>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/storages`;
         return this.getList(url, options.limit, options.offset);

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -114,7 +114,7 @@ export class Users extends CrowdinApi {
      * @param options optional parameters for the request
      * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
      */
-    listUsers(options?: UsersModel.ListUsersRequest): Promise<ResponseList<UsersModel.User>>;
+    listUsers(options?: UsersModel.ListUsersOptions): Promise<ResponseList<UsersModel.User>>;
     /**
      * @param status filter users by status
      * @param search search users by firstName, lastName, username, email
@@ -132,7 +132,7 @@ export class Users extends CrowdinApi {
         offset?: number,
     ): Promise<ResponseList<UsersModel.User>>;
     listUsers(
-        options?: UsersModel.Status | UsersModel.ListUsersRequest,
+        options?: UsersModel.Status | UsersModel.ListUsersOptions,
         deprecatedSearch?: string,
         deprecatedTwoFactor?: UsersModel.TwoFactor,
         deprecatedLimit?: number,
@@ -180,7 +180,7 @@ export namespace UsersModel {
         languageId?: string;
     }
 
-    export interface ListUsersRequest extends PaginationOptions {
+    export interface ListUsersOptions extends PaginationOptions {
         status?: Status;
         search?: string;
         twoFactor?: TwoFactor;

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, Pagination, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, Pagination, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 export class Users extends CrowdinApi {
     /**
@@ -9,6 +9,7 @@ export class Users extends CrowdinApi {
      * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
      */
     listProjectMembers(
@@ -19,25 +20,38 @@ export class Users extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
+     */
     listProjectMembers(
         projectId: number,
-        searchOrRequest?: string | UsersModel.ListProjectMembersRequest,
-        role?: UsersModel.Role,
-        languageId?: string,
-        limit?: number,
-        offset?: number,
+        options?: UsersModel.ListProjectMembersOptions,
+    ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
+    listProjectMembers(
+        projectId: number,
+        options: string | UsersModel.ListProjectMembersOptions = {},
+        deprecatedRole?: UsersModel.Role,
+        deprecatedLanguageId?: string,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>> {
         let url = `${this.url}/projects/${projectId}/members`;
-        let request: UsersModel.ListProjectMembersRequest;
-        if (searchOrRequest && typeof searchOrRequest === 'object') {
-            request = searchOrRequest;
-        } else {
-            request = { search: searchOrRequest, role, languageId, limit, offset };
+        if (typeof options === 'string') {
+            options = {
+                search: options,
+                role: deprecatedRole,
+                languageId: deprecatedLanguageId,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'search', request.search);
-        url = this.addQueryParam(url, 'role', request.role);
-        url = this.addQueryParam(url, 'languageId', request.languageId);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'search', options.search);
+        url = this.addQueryParam(url, 'role', options.role);
+        url = this.addQueryParam(url, 'languageId', options.languageId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -100,6 +114,7 @@ export class Users extends CrowdinApi {
      * @param twoFactor filter users by two-factor authentication status
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
      */
     listUsers(
@@ -109,24 +124,33 @@ export class Users extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<UsersModel.User>>;
+    /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
+     */
+    listUsers(options?: UsersModel.ListUsersRequest): Promise<ResponseList<UsersModel.User>>;
     listUsers(
-        statusOrRequest?: UsersModel.Status | UsersModel.ListUsersRequest,
-        search?: string,
-        twoFactor?: UsersModel.TwoFactor,
-        limit?: number,
-        offset?: number,
+        options: UsersModel.Status | UsersModel.ListUsersRequest = {},
+        deprecatedSearch?: string,
+        deprecatedTwoFactor?: UsersModel.TwoFactor,
+        deprecatedLimit?: number,
+        deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.User>> {
         let url = `${this.url}/users`;
-        let request: UsersModel.ListUsersRequest;
-        if (statusOrRequest && typeof statusOrRequest === 'object') {
-            request = statusOrRequest;
-        } else {
-            request = { status: statusOrRequest, search, twoFactor, limit, offset };
+        if (typeof options === 'string') {
+            options = {
+                status: options,
+                search: deprecatedSearch,
+                twoFactor: deprecatedTwoFactor,
+                limit: deprecatedLimit,
+                offset: deprecatedOffset,
+            };
+            this.emitDeprecationWarning();
         }
-        url = this.addQueryParam(url, 'status', request.status);
-        url = this.addQueryParam(url, 'search', request.search);
-        url = this.addQueryParam(url, 'twoFactor', request.twoFactor);
-        return this.getList(url, request.limit, request.offset);
+        url = this.addQueryParam(url, 'status', options.status);
+        url = this.addQueryParam(url, 'search', options.search);
+        url = this.addQueryParam(url, 'twoFactor', options.twoFactor);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -148,20 +172,16 @@ export class Users extends CrowdinApi {
 }
 
 export namespace UsersModel {
-    export interface ListProjectMembersRequest {
+    export interface ListProjectMembersOptions extends PaginationOptions {
         search?: string;
         role?: Role;
         languageId?: string;
-        limit?: number;
-        offset?: number;
     }
 
-    export interface ListUsersRequest {
+    export interface ListUsersRequest extends PaginationOptions {
         status?: Status;
         search?: string;
         twoFactor?: TwoFactor;
-        limit?: number;
-        offset?: number;
     }
 
     export interface User {

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -31,14 +31,14 @@ export class Users extends CrowdinApi {
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
     listProjectMembers(
         projectId: number,
-        options: string | UsersModel.ListProjectMembersOptions = {},
+        options?: string | UsersModel.ListProjectMembersOptions,
         deprecatedRole?: UsersModel.Role,
         deprecatedLanguageId?: string,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>> {
         let url = `${this.url}/projects/${projectId}/members`;
-        if (typeof options === 'string') {
+        if (typeof options === 'string' || typeof options === 'undefined') {
             options = {
                 search: options,
                 role: deprecatedRole,
@@ -130,14 +130,14 @@ export class Users extends CrowdinApi {
      */
     listUsers(options?: UsersModel.ListUsersRequest): Promise<ResponseList<UsersModel.User>>;
     listUsers(
-        options: UsersModel.Status | UsersModel.ListUsersRequest = {},
+        options?: UsersModel.Status | UsersModel.ListUsersRequest,
         deprecatedSearch?: string,
         deprecatedTwoFactor?: UsersModel.TwoFactor,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.User>> {
         let url = `${this.url}/users`;
-        if (typeof options === 'string') {
+        if (typeof options === 'string' || typeof options === 'undefined') {
             options = {
                 status: options,
                 search: deprecatedSearch,

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    Pagination,
-    PaginationOptions,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalString, Pagination, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 export class Users extends CrowdinApi {
     /**
@@ -44,7 +37,7 @@ export class Users extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>> {
         let url = `${this.url}/projects/${projectId}/members`;
-        if (typeof options === 'string' || typeof options === 'undefined') {
+        if (isOptionalString(options)) {
             options = {
                 search: options,
                 role: deprecatedRole,
@@ -52,7 +45,6 @@ export class Users extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'search', options.search);
         url = this.addQueryParam(url, 'role', options.role);
@@ -139,7 +131,7 @@ export class Users extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.User>> {
         let url = `${this.url}/users`;
-        if (typeof options === 'string' || typeof options === 'undefined') {
+        if (isOptionalString(options)) {
             options = {
                 status: options,
                 search: deprecatedSearch,
@@ -147,7 +139,6 @@ export class Users extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'status', options.status);
         url = this.addQueryParam(url, 'search', options.search);

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -2,14 +2,22 @@ import { CrowdinApi, Pagination, PaginationOptions, ResponseList, ResponseObject
 
 export class Users extends CrowdinApi {
     /**
-     *
+     * @param projectId project identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
+     */
+    listProjectMembers(
+        projectId: number,
+        options?: UsersModel.ListProjectMembersOptions,
+    ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
+    /**
      * @param projectId project identifier
      * @param search search users by firstName, lastName or username
      * @param role defines role type
      * @param languageId language identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
      */
     listProjectMembers(
@@ -19,15 +27,6 @@ export class Users extends CrowdinApi {
         languageId?: string,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.getMany
-     */
-    listProjectMembers(
-        projectId: number,
-        options?: UsersModel.ListProjectMembersOptions,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>>;
     listProjectMembers(
         projectId: number,
@@ -55,7 +54,6 @@ export class Users extends CrowdinApi {
     }
 
     /**
-     *
      * @param projectId project identifier
      * @param request request body
      * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.post
@@ -69,7 +67,6 @@ export class Users extends CrowdinApi {
     }
 
     /**
-     *
      * @param projectId project identifier
      * @param memberId member identifier
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.members.get
@@ -83,7 +80,6 @@ export class Users extends CrowdinApi {
     }
 
     /**
-     *
      * @param projectId project identifier
      * @param memberId member identifier
      * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.put
@@ -98,7 +94,6 @@ export class Users extends CrowdinApi {
     }
 
     /**
-     *
      * @param projectId project identifier
      * @param memberId member identifier
      * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.members.delete
@@ -109,12 +104,17 @@ export class Users extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
+     */
+    listUsers(options?: UsersModel.ListUsersRequest): Promise<ResponseList<UsersModel.User>>;
+    /**
      * @param status filter users by status
      * @param search search users by firstName, lastName, username, email
      * @param twoFactor filter users by two-factor authentication status
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
      */
     listUsers(
@@ -124,11 +124,6 @@ export class Users extends CrowdinApi {
         limit?: number,
         offset?: number,
     ): Promise<ResponseList<UsersModel.User>>;
-    /**
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.users.getMany
-     */
-    listUsers(options?: UsersModel.ListUsersRequest): Promise<ResponseList<UsersModel.User>>;
     listUsers(
         options?: UsersModel.Status | UsersModel.ListUsersRequest,
         deprecatedSearch?: string,

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, Pagination, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    Pagination,
+    PaginationOptions,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Users extends CrowdinApi {
     /**
@@ -45,7 +52,7 @@ export class Users extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'search', options.search);
         url = this.addQueryParam(url, 'role', options.role);
@@ -140,7 +147,7 @@ export class Users extends CrowdinApi {
                 limit: deprecatedLimit,
                 offset: deprecatedOffset,
             };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'status', options.status);
         url = this.addQueryParam(url, 'search', options.search);

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -2,17 +2,17 @@ import { CrowdinApi, PaginationOptions, ResponseList } from '../core';
 
 export class Vendors extends CrowdinApi {
     /**
-     * @param limit maximum number of items to retrieve (default 25)
-     * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
-     */
-    listVendors(limit?: number, offset?: number): Promise<ResponseList<VendorsModel.Vendor>>;
-    /**
-     * @param options optional pagination options for the request
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
      */
     listVendors(options?: PaginationOptions): Promise<ResponseList<VendorsModel.Vendor>>;
+    /**
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
+     */
+    listVendors(limit?: number, offset?: number): Promise<ResponseList<VendorsModel.Vendor>>;
     listVendors(
         options?: number | PaginationOptions,
         deprecatedOffset?: number,

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PaginationOptions, ResponseList } from '../core';
+import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList } from '../core';
 
 export class Vendors extends CrowdinApi {
     /**
@@ -19,7 +19,7 @@ export class Vendors extends CrowdinApi {
     ): Promise<ResponseList<VendorsModel.Vendor>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/vendors`;
         return this.getList(url, options.limit, options.offset);

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -14,10 +14,10 @@ export class Vendors extends CrowdinApi {
      */
     listVendors(options?: PaginationOptions): Promise<ResponseList<VendorsModel.Vendor>>;
     listVendors(
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<VendorsModel.Vendor>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList } from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, ResponseList } from '../core';
 
 export class Vendors extends CrowdinApi {
     /**
@@ -17,9 +17,8 @@ export class Vendors extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<VendorsModel.Vendor>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/vendors`;
         return this.getList(url, options.limit, options.offset);

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -1,14 +1,28 @@
-import { CrowdinApi, ResponseList } from '../core';
+import { CrowdinApi, PaginationOptions, ResponseList } from '../core';
 
 export class Vendors extends CrowdinApi {
     /**
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
      */
-    listVendors(limit?: number, offset?: number): Promise<ResponseList<VendorsModel.Vendor>> {
+    listVendors(limit?: number, offset?: number): Promise<ResponseList<VendorsModel.Vendor>>;
+    /**
+     * @param options optional pagination options for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.vendors.getMany
+     */
+    listVendors(options?: PaginationOptions): Promise<ResponseList<VendorsModel.Vendor>>;
+    listVendors(
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<VendorsModel.Vendor>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/vendors`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 }
 

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,15 +1,31 @@
-import { CrowdinApi, PatchRequest, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Webhooks extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
+     * @deprecated Optional parameters should be passed through an object
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
      */
-    listWebhooks(projectId: number, limit?: number, offset?: number): Promise<ResponseList<WebhooksModel.Webhook>> {
+    listWebhooks(projectId: number, limit?: number, offset?: number): Promise<ResponseList<WebhooksModel.Webhook>>;
+    /**
+     * @param projectId project identifier
+     * @param options optional pagination options
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
+     */
+    listWebhooks(projectId: number, options?: PaginationOptions): Promise<ResponseList<WebhooksModel.Webhook>>;
+    listWebhooks(
+        projectId: number,
+        options: number | PaginationOptions = {},
+        deprecatedOffset?: number,
+    ): Promise<ResponseList<WebhooksModel.Webhook>> {
+        if (typeof options === 'number') {
+            options = { limit: options, offset: deprecatedOffset };
+            this.emitDeprecationWarning();
+        }
         const url = `${this.url}/projects/${projectId}/webhooks`;
-        return this.getList(url, limit, offset);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -3,18 +3,18 @@ import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObje
 export class Webhooks extends CrowdinApi {
     /**
      * @param projectId project identifier
-     * @param limit maximum number of items to retrieve (default 25)
-     * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
-     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
-     */
-    listWebhooks(projectId: number, limit?: number, offset?: number): Promise<ResponseList<WebhooksModel.Webhook>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional pagination options
+     * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
      */
     listWebhooks(projectId: number, options?: PaginationOptions): Promise<ResponseList<WebhooksModel.Webhook>>;
+    /**
+     * @param projectId project identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @deprecated optional parameters should be passed through an object
+     * @see https://support.crowdin.com/api/v2/#operation/api.projects.webhooks.getMany
+     */
+    listWebhooks(projectId: number, limit?: number, offset?: number): Promise<ResponseList<WebhooksModel.Webhook>>;
     listWebhooks(
         projectId: number,
         options?: number | PaginationOptions,

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -17,10 +17,10 @@ export class Webhooks extends CrowdinApi {
     listWebhooks(projectId: number, options?: PaginationOptions): Promise<ResponseList<WebhooksModel.Webhook>>;
     listWebhooks(
         projectId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WebhooksModel.Webhook>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,11 +1,4 @@
-import {
-    CrowdinApi,
-    emitDeprecationWarning,
-    PaginationOptions,
-    PatchRequest,
-    ResponseList,
-    ResponseObject,
-} from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
 
 export class Webhooks extends CrowdinApi {
     /**
@@ -27,9 +20,8 @@ export class Webhooks extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WebhooksModel.Webhook>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/webhooks`;
         return this.getList(url, options.limit, options.offset);

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,4 +1,11 @@
-import { CrowdinApi, PaginationOptions, PatchRequest, ResponseList, ResponseObject } from '../core';
+import {
+    CrowdinApi,
+    emitDeprecationWarning,
+    PaginationOptions,
+    PatchRequest,
+    ResponseList,
+    ResponseObject,
+} from '../core';
 
 export class Webhooks extends CrowdinApi {
     /**
@@ -22,7 +29,7 @@ export class Webhooks extends CrowdinApi {
     ): Promise<ResponseList<WebhooksModel.Webhook>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/webhooks`;
         return this.getList(url, options.limit, options.offset);

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, isOptionalNumber, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 export class Workflows extends CrowdinApi {
     /**
@@ -27,9 +27,8 @@ export class Workflows extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>> {
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { limit: options, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/workflow-steps`;
         return this.getList(url, options.limit, options.offset);
@@ -73,9 +72,8 @@ export class Workflows extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>> {
         let url = `${this.url}/workflow-templates`;
-        if (typeof options === 'number' || typeof options === 'undefined') {
+        if (isOptionalNumber(options)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'groupId', options.groupId);
         return this.getList(url, options.limit, options.offset);

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -24,10 +24,10 @@ export class Workflows extends CrowdinApi {
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>>;
     listWorkflowSteps(
         projectId: number,
-        options: number | PaginationOptions = {},
+        options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>> {
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }
@@ -68,12 +68,12 @@ export class Workflows extends CrowdinApi {
         options?: WorkflowModel.ListWorkflowTemplatesRequest,
     ): Promise<ResponseList<WorkflowModel.Workflow>>;
     listWorkflowTemplates(
-        options: number | WorkflowModel.ListWorkflowTemplatesRequest = {},
+        options?: number | WorkflowModel.ListWorkflowTemplatesRequest,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>> {
         let url = `${this.url}/workflow-templates`;
-        if (typeof options === 'number') {
+        if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
             this.emitDeprecationWarning();
         }

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,4 +1,4 @@
-import { CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../core';
+import { CrowdinApi, emitDeprecationWarning, PaginationOptions, ResponseList, ResponseObject } from '../core';
 
 export class Workflows extends CrowdinApi {
     /**
@@ -29,7 +29,7 @@ export class Workflows extends CrowdinApi {
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>> {
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { limit: options, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         const url = `${this.url}/projects/${projectId}/workflow-steps`;
         return this.getList(url, options.limit, options.offset);
@@ -75,7 +75,7 @@ export class Workflows extends CrowdinApi {
         let url = `${this.url}/workflow-templates`;
         if (typeof options === 'number' || typeof options === 'undefined') {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
-            this.emitDeprecationWarning();
+            emitDeprecationWarning();
         }
         url = this.addQueryParam(url, 'groupId', options.groupId);
         return this.getList(url, options.limit, options.offset);

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -53,7 +53,7 @@ export class Workflows extends CrowdinApi {
      * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.getMany
      */
     listWorkflowTemplates(
-        options?: WorkflowModel.ListWorkflowTemplatesRequest,
+        options?: WorkflowModel.ListWorkflowTemplatesOptions,
     ): Promise<ResponseList<WorkflowModel.Workflow>>;
     /**
      * @param groupId group identifier
@@ -68,7 +68,7 @@ export class Workflows extends CrowdinApi {
         offset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>>;
     listWorkflowTemplates(
-        options?: number | WorkflowModel.ListWorkflowTemplatesRequest,
+        options?: number | WorkflowModel.ListWorkflowTemplatesOptions,
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>> {
@@ -105,7 +105,7 @@ export namespace WorkflowModel {
               }
             | never[];
     }
-    export interface ListWorkflowTemplatesRequest extends PaginationOptions {
+    export interface ListWorkflowTemplatesOptions extends PaginationOptions {
         groupId?: number;
     }
 

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -3,24 +3,24 @@ import { CrowdinApi, PaginationOptions, ResponseList, ResponseObject } from '../
 export class Workflows extends CrowdinApi {
     /**
      * @param projectId project identifier
+     * @param options optional pagination parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.workflow-steps.getMany
+     */
+    listWorkflowSteps(
+        projectId: number,
+        options?: PaginationOptions,
+    ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>>;
+    /**
+     * @param projectId project identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.workflow-steps.getMany
      */
     listWorkflowSteps(
         projectId: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>>;
-    /**
-     * @param projectId project identifier
-     * @param options optional pagination options for the request
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.workflow-steps.getMany
-     */
-    listWorkflowSteps(
-        projectId: number,
-        options?: PaginationOptions,
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>>;
     listWorkflowSteps(
         projectId: number,
@@ -49,23 +49,23 @@ export class Workflows extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.getMany
+     */
+    listWorkflowTemplates(
+        options?: WorkflowModel.ListWorkflowTemplatesRequest,
+    ): Promise<ResponseList<WorkflowModel.Workflow>>;
+    /**
      * @param groupId group identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)
-     * @deprecated Optional parameters should be passed through an object
+     * @deprecated optional parameters should be passed through an object
      * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.getMany
      */
     listWorkflowTemplates(
         groupId?: number,
         limit?: number,
         offset?: number,
-    ): Promise<ResponseList<WorkflowModel.Workflow>>;
-    /**
-     * @param options optional parameters for the request
-     * @see https://support.crowdin.com/enterprise/api/#operation/api.workflow-templates.getMany
-     */
-    listWorkflowTemplates(
-        options?: WorkflowModel.ListWorkflowTemplatesRequest,
     ): Promise<ResponseList<WorkflowModel.Workflow>>;
     listWorkflowTemplates(
         options?: number | WorkflowModel.ListWorkflowTemplatesRequest,

--- a/tests/glossaries/api.test.ts
+++ b/tests/glossaries/api.test.ts
@@ -260,7 +260,7 @@ describe('Glossaries API', () => {
     });
 
     it('List glossaries', async () => {
-        const glossaries = await api.listGlossaries(groupId);
+        const glossaries = await api.listGlossaries({ groupId });
         expect(glossaries.data.length).toBe(1);
         expect(glossaries.data[0].data.id).toBe(glossaryId);
         expect(glossaries.data[0].data.name).toBe(glossaryName);

--- a/tests/machineTranslation/api.test.ts
+++ b/tests/machineTranslation/api.test.ts
@@ -117,7 +117,7 @@ describe('Machine Translation engines (MTs) API', () => {
     });
 
     it('List MTs', async () => {
-        const mts = await api.listMts(groupId);
+        const mts = await api.listMts({ groupId });
         expect(mts.data.length).toBe(1);
         expect(mts.data[0].data.id).toBe(mtId);
         expect(mts.pagination.limit).toBe(limit);

--- a/tests/sourceFiles/api.test.ts
+++ b/tests/sourceFiles/api.test.ts
@@ -387,7 +387,7 @@ describe('Source Files API', () => {
     });
 
     it('List project branches', async () => {
-        const branches = await api.listProjectBranches(projectId, branchName);
+        const branches = await api.listProjectBranches(projectId, { name: branchName });
         expect(branches.data.length).toBe(1);
         expect(branches.data[0].data.id).toBe(branchId);
         expect(branches.pagination.limit).toBe(limit);

--- a/tests/stringComments/api.test.ts
+++ b/tests/stringComments/api.test.ts
@@ -103,7 +103,7 @@ describe('String Comments API', () => {
     });
 
     it('List string comment', async () => {
-        const comments = await api.listStringComments(projectId, stringId);
+        const comments = await api.listStringComments(projectId, { stringId });
         expect(comments.data.length).toBe(1);
         expect(comments.data[0].data.id).toBe(stringCommentId);
         expect(comments.pagination.limit).toBe(limit);

--- a/tests/translationMemory/api.test.ts
+++ b/tests/translationMemory/api.test.ts
@@ -170,7 +170,7 @@ describe('Translation Memory API', () => {
     });
 
     it('List TM', async () => {
-        const tms = await api.listTm(groupId);
+        const tms = await api.listTm({ groupId });
         expect(tms.data.length).toBe(1);
         expect(tms.data[0].data.id).toBe(tmId);
         expect(tms.pagination.limit).toBe(limit);


### PR DESCRIPTION
This PR completes the first part of #137 in a semver: minor way by adding overloads to all functions that support optional parameters to allow them to be passed through an object instead of consecutive parameters (except for very rare cases). This results in an overall better user experience so that we don't have to keep passing `undefined` when we want to ignore a parameter.
This PR also adds a deprecation warning that will be sent on the first time a user passes optional parameters outside of an object to alert them for the change that I would like to bring into the library later on that will remove support for consecutive parameters in a future major version release.
Lastly, I'm opening this PR as a draft because I'm aware I introduced many inconsistencies along the way as it took several days to make this and a lot of things had to be added, so I will be going over the changes in the coming days but I would also like to know your feedback on this change so far.
~~There is also currently a bug where if the first optional parameter is passed as undefined, every other parameter will be ignored. That will be fixed in the next couple of days too.~~ This has been fixed