### PR TITLE
types: improve types by reducing the use of `any`

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,7 +3,7 @@ import { FetchClient } from './internal/fetch/fetchClient';
 import { RetryConfig, RetryService } from './internal/retry';
 
 export interface RequestConfig {
-    headers?: any;
+    headers?: Record<string, string>;
     mode?: string;
 }
 
@@ -11,9 +11,9 @@ export interface HttpClient {
     get<T>(url: string, config?: RequestConfig): Promise<T>;
     delete<T>(url: string, config?: RequestConfig): Promise<T>;
     head<T>(url: string, config?: RequestConfig): Promise<T>;
-    post<T>(url: string, data?: any, config?: RequestConfig): Promise<T>;
-    put<T>(url: string, data?: any, config?: RequestConfig): Promise<T>;
-    patch<T>(url: string, data?: any, config?: RequestConfig): Promise<T>;
+    post<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T>;
+    put<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T>;
+    patch<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T>;
 }
 
 export enum HttpClientType {
@@ -158,7 +158,7 @@ export abstract class CrowdinApi {
         this.config = config;
     }
 
-    protected addQueryParam(url: string, name: string, value?: any): string {
+    protected addQueryParam(url: string, name: string, value?: string | number): string {
         if (value) {
             url += new RegExp(/\?.+=.*/g).test(url) ? '&' : '?';
             url += `${name}=${value}`;
@@ -166,8 +166,10 @@ export abstract class CrowdinApi {
         return url;
     }
 
-    protected defaultConfig(): any {
-        const config: any = {
+    protected defaultConfig(): { headers: Record<string, string> } {
+        const config: {
+            headers: Record<string, string>;
+        } = {
             headers: {
                 Authorization: `Bearer ${this.token}`,
             },
@@ -209,7 +211,7 @@ export abstract class CrowdinApi {
         url: string,
         limit?: number,
         offset?: number,
-        config?: { headers: any },
+        config?: { headers: Record<string, string> },
     ): Promise<ResponseList<T>> {
         const conf = config ?? this.defaultConfig();
         if (this.fetchAllFlag) {
@@ -224,9 +226,9 @@ export abstract class CrowdinApi {
         }
     }
 
-    protected async fetchAll<T = any>(
+    protected async fetchAll<T>(
         url: string,
-        config: { headers: any },
+        config: { headers: Record<string, string> },
         maxAmount?: number,
     ): Promise<ResponseList<T>> {
         let limit = 500;
@@ -259,27 +261,27 @@ export abstract class CrowdinApi {
 
     //Http overrides
 
-    protected get<T>(url: string, config?: { headers: any }): Promise<T> {
+    protected get<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.get(url, config));
     }
 
-    protected delete<T>(url: string, config?: { headers: any }): Promise<T> {
+    protected delete<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.delete(url, config));
     }
 
-    protected head<T>(url: string, config?: { headers: any }): Promise<T> {
+    protected head<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.head(url, config));
     }
 
-    protected post<T>(url: string, data?: any, config?: { headers: any }): Promise<T> {
+    protected post<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.post(url, data, config));
     }
 
-    protected put<T>(url: string, data?: any, config?: { headers: any }): Promise<T> {
+    protected put<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.put(url, data, config));
     }
 
-    protected patch<T>(url: string, data?: any, config?: { headers: any }): Promise<T> {
+    protected patch<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.retryService.executeAsyncFunc(() => this.httpClient.patch(url, data, config));
     }
 }

--- a/src/core/internal/axios/axiosProvider.ts
+++ b/src/core/internal/axios/axiosProvider.ts
@@ -13,7 +13,7 @@ export class AxisProvider {
         this.configureResponse();
     }
 
-    private configureRequest(): any {
+    private configureRequest(): void {
         this.axios.interceptors.request.use(config => {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             return new Promise(resolve => {
@@ -28,7 +28,7 @@ export class AxisProvider {
         });
     }
 
-    private configureResponse(): any {
+    private configureResponse(): void {
         this.axios.interceptors.response.use(
             response => {
                 this.pendingRequests = Math.max(0, this.pendingRequests - 1);

--- a/src/core/internal/fetch/fetchClient.ts
+++ b/src/core/internal/fetch/fetchClient.ts
@@ -7,27 +7,27 @@ export class FetchClient implements HttpClient {
     private requestIntervalMs = 10;
     private pendingRequests = 0;
 
-    get(url: string, config?: { headers: any }): Promise<any> {
+    get<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'GET', config);
     }
-    delete(url: string, config?: { headers: any }): Promise<any> {
+    delete<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'DELETE', config);
     }
-    head(url: string, config?: { headers: any }): Promise<any> {
+    head<T>(url: string, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'HEAD', config);
     }
-    post(url: string, data?: any, config?: { headers: any }): Promise<any> {
+    post<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'POST', config, data);
     }
-    put(url: string, data?: any, config?: { headers: any }): Promise<any> {
+    put<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'PUT', config, data);
     }
-    patch(url: string, data?: any, config?: { headers: any }): Promise<any> {
+    patch<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T> {
         return this.request(url, 'PATCH', config, data);
     }
 
-    private async request(url: string, method: string, config?: RequestConfig, data?: any): Promise<any> {
-        let body = undefined;
+    private async request<T>(url: string, method: string, config?: RequestConfig, data?: unknown): Promise<T> {
+        let body;
         if (data) {
             if (typeof data === 'object' && !this.isBuffer(data)) {
                 body = JSON.stringify(data);
@@ -46,13 +46,13 @@ export class FetchClient implements HttpClient {
             mode: config?.mode ?? 'no-cors',
             body: body,
         })
-            .then(async (resp: any) => {
-                if (resp.status === 204) {
+            .then(async (res: any) => {
+                if (res.status === 204) {
                     return {};
                 }
-                const text = await resp.text();
+                const text = await res.text();
                 const json = text ? JSON.parse(text) : {};
-                if (resp.status >= 200 && resp.status < 300) {
+                if (res.status >= 200 && res.status < 300) {
                     return json;
                 } else {
                     throw json;
@@ -61,7 +61,7 @@ export class FetchClient implements HttpClient {
             .finally(() => (this.pendingRequests = Math.max(0, this.pendingRequests - 1)));
     }
 
-    private isBuffer(data: any): boolean {
+    private isBuffer(data: unknown): boolean {
         if (typeof ArrayBuffer === 'function') {
             return ArrayBuffer.isView(data);
         } else if (typeof Buffer === 'function') {

--- a/src/core/internal/retry/index.ts
+++ b/src/core/internal/retry/index.ts
@@ -8,7 +8,7 @@ export interface RetryConfig {
 }
 
 export interface SkipRetryCondition {
-    test(error: any): boolean;
+    test(error: unknown): boolean;
 }
 
 export class RetryService {

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -254,7 +254,7 @@ export namespace GlossariesModel {
 
     export interface GlossaryImportStatusAttribute {
         storageId: number;
-        scheme: any;
+        scheme: unknown;
         firstLineContainsHeader: boolean;
     }
 

--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -128,7 +128,8 @@ export namespace ReportsModel {
     export interface ReportStatusAttributes {
         format: Format;
         reportName: string;
-        schema: any;
+        //TODO improve this type with unions and generics according to the documentation
+        schema: unknown;
     }
 
     export interface GroupTranslationCostSchema {

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -110,6 +110,7 @@ export namespace TeamsModel {
         teamId: number;
         accessToAllWorkflowSteps?: boolean;
         managerAccess?: boolean;
+        //TODO improve this type by splitting it into API v2 and Enterprise API
         permissions?: any;
     }
 
@@ -122,6 +123,7 @@ export namespace TeamsModel {
         id: number;
         hasManagerAccess: boolean;
         hasAccessToAllWorkflowSteps: boolean;
+        //TODO improve this type by splitting it into API v2 and Enterprise API
         permissions: any;
     }
 

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -243,6 +243,7 @@ export namespace UsersModel {
         userIds: number[];
         accessToAllWorkflowSteps?: boolean;
         managerAccess?: boolean;
+        //TODO improve this type by splitting it into API v2 and Enterprise API
         permissions?: any;
     }
 
@@ -255,6 +256,7 @@ export namespace UsersModel {
     export interface ReplaceProjectMemberRequest {
         accessToAllWorkflowSteps?: boolean;
         managerAccess?: boolean;
+        //TODO improve this type by splitting it into API v2 and Enterprise API
         permissions?: any;
     }
 }

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -85,8 +85,9 @@ export namespace WebhooksModel {
         batchingEnabled?: boolean;
         contentType?: ContentType;
         events: Event[];
-        headers?: any;
+        headers?: Record<string, string>;
         requestType: RequestType;
+        //TODO improve this type, needs better documentation
         payload?: any;
     }
 


### PR DESCRIPTION
I noticed there were a lot of `any` types scattered around the library so I replaced them with what I think they should actually be and added TODO comments to fix the ones I didn't as they would require a semver: major change. If you're in doubt about any of the changes let me know and I can explain the reasoning behind them!