### PR TITLE
refactor: remove string enums

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,10 +11,7 @@ export interface HttpClient {
     patch<T>(url: string, data?: unknown, config?: { headers: Record<string, string> }): Promise<T>;
 }
 
-export enum HttpClientType {
-    AXIOS = 'axios',
-    FETCH = 'fetch',
-}
+export type HttpClientType = 'axios' | 'fetch';
 
 export interface Credentials {
     token: string;
@@ -74,14 +71,7 @@ export interface PatchRequest {
     path: string;
 }
 
-export enum PatchOperation {
-    ADD = 'add',
-    REMOVE = 'remove',
-    REPLACE = 'replace',
-    MOVE = 'move',
-    copy = 'copy',
-    TEST = 'test',
-}
+export type PatchOperation = 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
 
 export interface DownloadLink {
     url: string;
@@ -186,9 +176,9 @@ export abstract class CrowdinApi {
         }
         if (this.config?.httpClientType) {
             switch (this.config.httpClientType) {
-                case HttpClientType.AXIOS:
+                case 'axios':
                     return CrowdinApi.AXIOS_INSTANCE;
-                case HttpClientType.FETCH:
+                case 'fetch':
                     return CrowdinApi.FETCH_INSTANCE;
                 default:
                     return CrowdinApi.AXIOS_INSTANCE;

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -336,33 +336,28 @@ export namespace GlossariesModel {
         translationOfTermId?: number;
     }
 
-    export enum GlossaryFormat {
-        TBX = 'tbx',
-        CSV = 'csv',
-        XLSX = 'xlsx',
-    }
+    export type GlossaryFormat = 'tbx' | 'csv' | 'xlsx';
 
     export interface GlossaryFileScheme {
         [key: string]: number;
     }
 
-    export enum PartOfSpeech {
-        ADJECTIVE = 'adjective',
-        ADPOSITION = 'adposition',
-        ADVERB = 'adverb',
-        AUXILIARY = 'auxiliary',
-        COORDINATING_CONJUNCTION = 'coordinating conjunction',
-        DETERMINER = 'determiner',
-        INTERJECTION = 'interjection',
-        NOUN = 'noun',
-        NUMERAL = 'numeral',
-        PARTICLE = 'particle',
-        PRONOUN = 'pronoun',
-        PROPER_NOUN = 'proper noun',
-        SUBORDINATING_CONJUNCTION = 'subordinating conjunction',
-        VERB = 'verb',
-        OTHER = 'other',
-    }
+    export type PartOfSpeech =
+        | 'adjective'
+        | 'adposition'
+        | 'adverb'
+        | 'auxiliary'
+        | 'coordinating conjunction'
+        | 'determiner'
+        | 'interjection'
+        | 'noun'
+        | 'numeral'
+        | 'particle'
+        | 'pronoun'
+        | 'proper noun'
+        | 'subordinating conjunction'
+        | 'verb'
+        | 'other';
 
     export interface ListGlossariesOptions extends PaginationOptions {
         groupId?: number;

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -66,19 +66,9 @@ export class Issues extends CrowdinApi {
  * @deprecated
  */
 export namespace IssuesModel {
-    export enum Type {
-        ALL = 'all',
-        GENERAL_QUESTION = 'general_question',
-        TRANSLATION_MISTAKE = 'translation_mistake',
-        CONTEXT_REQUEST = 'context_request',
-        SOURCE_MISTAKE = 'source_mistake',
-    }
+    export type Type = 'all' | 'general_question' | 'translation_mistake' | 'context_request' | 'source_mistake';
 
-    export enum Status {
-        ALL = 'all',
-        RESOLVED = 'resolved',
-        UNRESOLVED = 'unresolved',
-    }
+    export type Status = 'all' | 'resolved' | 'unresolved';
 
     export interface Issue {
         id: number;

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -91,8 +91,5 @@ export namespace LanguagesModel {
         pluralCategoryNames: string[];
     }
 
-    export enum TextDirection {
-        LTR = 'ltr',
-        RTL = 'rtl',
-    }
+    export type TextDirection = 'ltr' | 'rtl';
 }

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -124,10 +124,7 @@ export namespace MachineTranslationModel {
         translations: string[];
     }
 
-    export enum LanguageRecognitionProvider {
-        CROWDIN = 'crowdin',
-        ENGINE = 'engine',
-    }
+    export type LanguageRecognitionProvider = 'crowdin' | 'engine';
 
     export interface ListMTsOptions extends PaginationOptions {
         groupId?: number;

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -348,15 +348,9 @@ export namespace ProjectsGroupsModel {
         STRINGS_BASED = 1,
     }
 
-    export enum JoinPolicy {
-        OPEN = 'open',
-        PRIVATE = 'private',
-    }
+    export type JoinPolicy = 'open' | 'private';
 
-    export enum LanguageAccessPolicy {
-        OPEN = 'open',
-        MODERATE = 'moderate',
-    }
+    export type LanguageAccessPolicy = 'open' | 'moderate';
 
     export interface CheckCategories {
         empty: boolean;

--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -202,43 +202,33 @@ export namespace ReportsModel {
         dateTo?: string;
     }
 
-    export enum Unit {
-        STRINGS = 'strings',
-        WORDS = 'words',
-        CHARS = 'chars',
-        CHARS_WITH_SPACES = 'chars_with_spaces',
-    }
+    export type Unit = 'strings' | 'words' | 'chars' | 'chars_with_spaces';
 
-    export enum Currency {
-        USD = 'USD',
-        EUR = 'EUR',
-        JPY = 'JPY',
-        GBP = 'GBP',
-        AUD = 'AUD',
-        CAD = 'CAD',
-        CHF = 'CHF',
-        CNY = 'CNY',
-        SEK = 'SEK',
-        NZD = 'NZD',
-        MXN = 'MXN',
-        SGD = 'SGD',
-        HKD = 'HKD',
-        NOK = 'NOK',
-        KRW = 'KRW',
-        TRY = 'TRY',
-        RUB = 'RUB',
-        INR = 'INR',
-        BRL = 'BRL',
-        ZAR = 'ZAR',
-        GEL = 'GEL',
-        UAH = 'UAH',
-    }
+    export type Currency =
+        | 'USD'
+        | 'EUR'
+        | 'JPY'
+        | 'GBP'
+        | 'AUD'
+        | 'CAD'
+        | 'CHF'
+        | 'CNY'
+        | 'SEK'
+        | 'NZD'
+        | 'MXN'
+        | 'SGD'
+        | 'HKD'
+        | 'NOK'
+        | 'KRW'
+        | 'TRY'
+        | 'RUB'
+        | 'INR'
+        | 'BRL'
+        | 'ZAR'
+        | 'GEL'
+        | 'UAH';
 
-    export enum Format {
-        XLSX = 'xlsx',
-        CSV = 'csv',
-        JSON = 'json',
-    }
+    export type Format = 'xlsx' | 'csv' | 'json';
 
     export interface TranslateStep {
         type: string;
@@ -264,20 +254,9 @@ export namespace ReportsModel {
         rates: RegularRate[];
     }
 
-    export enum Mode {
-        NO_MATCH = 'no_match',
-        TM_MATCH = 'tm_match',
-        APPROVAL = 'approval',
-    }
+    export type Mode = 'no_match' | 'tm_match' | 'approval';
 
-    export enum ContributionMode {
-        TRANSLATIONS = 'translations',
-        APPROVALS = 'approvals',
-        VOTES = 'votes',
-    }
+    export type ContributionMode = 'translations' | 'approvals' | 'votes';
 
-    export enum GroupBy {
-        USER = 'user',
-        LANGUAGE = 'language',
-    }
+    export type GroupBy = 'user' | 'language';
 }

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -474,11 +474,7 @@ export namespace SourceFilesModel {
         priority?: Priority;
     }
 
-    export enum Priority {
-        LOW = 'low',
-        NORMAL = 'normal',
-        HIGH = 'high',
-    }
+    export type Priority = 'low' | 'normal' | 'high';
 
     export interface ListProjectDirectoriesOptions extends PaginationOptions {
         branchId?: number;
@@ -581,45 +577,44 @@ export namespace SourceFilesModel {
         words: number;
     }
 
-    export enum FileType {
-        AUTO = 'auto',
-        ANDROID = 'android',
-        MACOSX = 'macosx',
-        RESX = 'resx',
-        PROPERTIES = 'properties',
-        GETTEXT = 'gettext',
-        YAML = 'yaml',
-        PHP = 'php',
-        JSON = 'json',
-        XML = 'xml',
-        INI = 'ini',
-        RC = 'rc',
-        RESW = 'resw',
-        RESJSON = 'resjson',
-        QTTS = 'qtts',
-        JOOMLA = 'joomla',
-        CHROME = 'chrome',
-        DTD = 'dtd',
-        DKLANG = 'dklang',
-        FLEX = 'flex',
-        NSH = 'nsh',
-        WXL = 'wxl',
-        XLIFF = 'xliff',
-        HTML = 'html',
-        HAML = 'haml',
-        TXT = 'txt',
-        CSV = 'csv',
-        MD = 'md',
-        FLSNP = 'flsnp',
-        FM_HTML = 'fm_html',
-        FM_MD = 'fm_md',
-        MEDIAWIKI = 'mediawiki',
-        DOCX = 'docx',
-        SBV = 'sbv',
-        VTT = 'vtt',
-        SRT = 'srt',
-        ARB = 'arb',
-    }
+    export type FileType =
+        | 'auto'
+        | 'android'
+        | 'macosx'
+        | 'resx'
+        | 'properties'
+        | 'gettext'
+        | 'yaml'
+        | 'php'
+        | 'json'
+        | 'xml'
+        | 'ini'
+        | 'rc'
+        | 'resw'
+        | 'resjson'
+        | 'qtts'
+        | 'joomla'
+        | 'chrome'
+        | 'dtd'
+        | 'dklang'
+        | 'flex'
+        | 'nsh'
+        | 'wxl'
+        | 'xliff'
+        | 'html'
+        | 'haml'
+        | 'txt'
+        | 'csv'
+        | 'md'
+        | 'flsnp'
+        | 'fm_html'
+        | 'fm_md'
+        | 'mediawiki'
+        | 'docx'
+        | 'sbv'
+        | 'vtt'
+        | 'srt'
+        | 'arb';
 
     export interface SpreadsheetImportOptions {
         firstLineContainsHeader: boolean;
@@ -662,11 +657,10 @@ export namespace SourceFilesModel {
         THREE = 3,
     }
 
-    export enum UpdateOption {
-        CLEAR_TRANSLATIONS_AND_APPROVALS = 'clear_translations_and_approvals',
-        KEEP_TRANSLATIONS = 'keep_translations',
-        KEEP_TRANSLATIONS_AND_APPROVALS = 'keep_translations_and_approvals',
-    }
+    export type UpdateOption =
+        | 'clear_translations_and_approvals'
+        | 'keep_translations'
+        | 'keep_translations_and_approvals';
 
     export interface ReviewedSourceFilesBuild {
         id: number;

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -192,9 +192,5 @@ export namespace SourceStringsModel {
         ICU = 2,
     }
 
-    export enum Scope {
-        IDENTIFIER = 'identifier',
-        TEXT = 'text',
-        CONTEXT = 'context',
-    }
+    export type Scope = 'identifier' | 'text' | 'context';
 }

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -158,20 +158,9 @@ export namespace StringCommentsModel {
         issueType?: IssueType;
     }
 
-    export enum Type {
-        COMMENT = 'comment',
-        ISSUE = 'issue',
-    }
+    export type Type = 'comment' | 'issue';
 
-    export enum IssueType {
-        GENERAL_QUESTION = 'general_question',
-        TRANSLATION_MISTAKE = 'translation_mistake',
-        CONTEXT_REQUEST = 'context_request',
-        SOURCE_MISTAKE = 'source_mistake',
-    }
+    export type IssueType = 'general_question' | 'translation_mistake' | 'context_request' | 'source_mistake';
 
-    export enum IssueStatus {
-        UNRESOLVED = 'unresolved',
-        RESOLVED = 'resolved',
-    }
+    export type IssueStatus = 'unresolved' | 'resolved';
 }

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -486,10 +486,7 @@ export namespace StringTranslationsModel {
         avatarUrl: string;
     }
 
-    export enum Mark {
-        UP = 'up',
-        DOWN = 'down',
-    }
+    export type Mark = 'up' | 'down';
 
     export interface ListStringTranslationsOptions extends PaginationOptions {
         denormalizePlaceholders?: BooleanInt;

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -285,12 +285,7 @@ export namespace TasksModel {
         wordsCount?: number;
     }
 
-    export enum Status {
-        TODO = 'todo',
-        IN_PROGRESS = 'in_progress',
-        DONE = 'done',
-        CLOSED = 'closed',
-    }
+    export type Status = 'todo' | 'in_progress' | 'done' | 'closed';
 
     export enum Type {
         TRANSLATE = 0,
@@ -318,86 +313,76 @@ export namespace TasksModel {
         percent: number;
     }
 
-    export enum Expertise {
-        STANDARD = 'standard',
-        MOBILE_APPLICATIONS = 'mobile-applications',
-        SOFTWARE_IT = 'software-it',
-        GAMING_VIDEO_GAMES = 'gaming-video-games',
-        TECHNICAL_ENGINEERING = 'technical-engineering',
-        MARKETING_CONSUMER_MEDIA = 'marketing-consumer-media',
-        BUSINESS_FINANCE = 'business-finance',
-        LEGAL_CERTIFICATE = 'legal-certificate',
-        CV = 'cv',
-        MEDICAL = 'medical',
-        PATENTS = 'patents',
-        AD_WORDS_BANNERS = 'ad-words-banners',
-        AUTOMOTIVE_AEROSPACE = 'automotive-aerospace',
-        SCIENTIFIC = 'scientific',
-        SCIENTIFIC_ACADEMIC = 'scientific-academic',
-        TOURISM = 'tourism',
-        CERTIFICATES_TRANSLATION = 'certificates-translation',
-        TRAINING_EMPLOYEE_HANDBOOKS = 'training-employee-handbooks',
-        FOREX_CRYPTO = 'forex-crypto',
-    }
+    export type Expertise =
+        | 'standard'
+        | 'mobile-applications'
+        | 'software-it'
+        | 'gaming-video-games'
+        | 'technical-engineering'
+        | 'marketing-consumer-media'
+        | 'business-finance'
+        | 'legal-certificate'
+        | 'cv'
+        | 'medical'
+        | 'patents'
+        | 'ad-words-banners'
+        | 'automotive-aerospace'
+        | 'scientific'
+        | 'scientific-academic'
+        | 'tourism'
+        | 'certificates-translation'
+        | 'training-employee-handbooks'
+        | 'forex-crypto';
 
-    export enum Tone {
-        EPTY = '',
-        INFORMAL = 'Informal',
-        FRIENDLY = 'Friendly',
-        BUSINESS = 'Business',
-        FORMAL = 'Formal',
-        OTHER = 'other',
-    }
+    export type Tone = '' | 'Informal' | 'Friendly' | 'Business' | 'Formal' | 'other';
 
-    export enum Purpose {
-        STANDARD = 'standard',
-        PERSONAL_USE = 'Personal use',
-        ONLINE_CONTENT = 'Online content',
-        APP_WEB_LOCALIZATION = 'App/Web localization',
-        MEDIA_CONTENT = 'Media content',
-        SEMI_TECHNICAL = 'Semi-technical',
-        OTHER = 'other',
-    }
+    export type Purpose =
+        | 'standard'
+        | 'Personal use'
+        | 'Online content'
+        | 'App/Web localization'
+        | 'Media content'
+        | 'Semi-technical'
+        | 'other';
 
-    export enum Subject {
-        GENERAL = 'general',
-        ACCOUNTING_FINANCE = 'accounting_finance',
-        AEROSPACE_DEFENCE = 'aerospace_defence',
-        ARCHITECTURE = 'architecture',
-        ART = 'art',
-        AUTOMOTIVE = 'automotive',
-        CERTIFICATES_DIPLOMAS_LICENCES_CV_ETC = 'certificates_diplomas_licences_cv_etc',
-        CHEMICAL = 'chemical',
-        CIVIL_ENGINEERING_CONSTRUCTION = 'civil_engineering_construction',
-        CORPORATE_SOCIAL_RESPONSIBILITY = 'corporate_social_responsibility',
-        COSMETICS = 'cosmetics',
-        CULINARY = 'culinary',
-        ELECTRONICS_ELECTRICAL_ENGINEERING = 'electronics_electrical_engineering',
-        ENERGY_POWER_GENERATION_OIL_GAS = 'energy_power_generation_oil_gas',
-        ENVIRONMENT = 'environment',
-        FASHION = 'fashion',
-        GAMES_VISEOGAMES_CASINO = 'games_viseogames_casino',
-        GENERAL_BUSINESS_COMMERCE = 'general_business_commerce',
-        HISTORY_ARCHAEOLOGY = 'history_archaeology',
-        INFORMATION_TECHNOLOGY = 'information_technology',
-        INSURANCE = 'insurance',
-        INTERNET_E_COMMERCE = 'internet_e-commerce',
-        LEGAL_DOCUMENTS_CONTRACTS = 'legal_documents_contracts',
-        LITERARY_TRANSLATIONS = 'literary_translations',
-        MARKETING_ADVERTISING_MATERIAL_PUBLIC_RELATIONS = 'marketing_advertising_material_public_relations',
-        MATEMATICS_AND_PHYSICS = 'matematics_and_physics',
-        MECHANICAL_MANUFACTURING = 'mechanical_manufacturing',
-        MEDIA_JOURNALISM_PUBLISHING = 'media_journalism_publishing',
-        MEDICAL_PHARMACEUTICAL = 'medical_pharmaceutical',
-        MUSIC = 'music',
-        PRIVATE_CORRESPONDENCE_LETTERS = 'private_correspondence_letters',
-        RELIGION = 'religion',
-        SCIENCE = 'science',
-        SHIPPING_SAILING_MARITIME = 'shipping_sailing_maritime',
-        SOCIAL_SCIENCE = 'social_science',
-        TELECOMMUNICATIONS = 'telecommunications',
-        TRAVEL_TOURISM = 'travel_tourism',
-    }
+    export type Subject =
+        | 'general'
+        | 'accounting_finance'
+        | 'aerospace_defence'
+        | 'architecture'
+        | 'art'
+        | 'automotive'
+        | 'certificates_diplomas_licences_cv_etc'
+        | 'chemical'
+        | 'civil_engineering_construction'
+        | 'corporate_social_responsibility'
+        | 'cosmetics'
+        | 'culinary'
+        | 'electronics_electrical_engineering'
+        | 'energy_power_generation_oil_gas'
+        | 'environment'
+        | 'fashion'
+        | 'games_viseogames_casino'
+        | 'general_business_commerce'
+        | 'history_archaeology'
+        | 'information_technology'
+        | 'insurance'
+        | 'internet_e-commerce'
+        | 'legal_documents_contracts'
+        | 'literary_translations'
+        | 'marketing_advertising_material_public_relations'
+        | 'matematics_and_physics'
+        | 'mechanical_manufacturing'
+        | 'media_journalism_publishing'
+        | 'medical_pharmaceutical'
+        | 'music'
+        | 'private_correspondence_letters'
+        | 'religion'
+        | 'science'
+        | 'shipping_sailing_maritime'
+        | 'social_science'
+        | 'telecommunications'
+        | 'travel_tourism';
 
     export interface ListTasksOptions extends PaginationOptions {
         status?: TasksModel.Status;

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -198,11 +198,7 @@ export namespace TranslationMemoryModel {
         scheme: Scheme;
     }
 
-    export enum Format {
-        TMX = 'tmx',
-        CSV = 'csv',
-        XLSX = 'xlsx',
-    }
+    export type Format = 'tmx' | 'csv' | 'xlsx';
 
     export interface Scheme {
         [key: string]: number;

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -267,59 +267,57 @@ export namespace TranslationStatusModel {
         approved: number;
     }
 
-    export enum Category {
-        EMPTY = 'empty',
-        VARIABLES = 'variables',
-        TAGS = 'tags',
-        PUNCTUATION = 'punctuation',
-        SYMBOL_REGISTER = 'symbol_register',
-        SPACES = 'spaces',
-        SIZE = 'size',
-        SPECIAL_SYMBOLS = 'special_symbols',
-        WRONG_TRANSLATION = 'wrong_translation',
-        SPELLCHECK = 'spellcheck',
-        ICU = 'icu',
-    }
+    export type Category =
+        | 'empty'
+        | 'variables'
+        | 'tags'
+        | 'punctuation'
+        | 'symbol_register'
+        | 'spaces'
+        | 'size'
+        | 'special_symbols'
+        | 'wrong_translation'
+        | 'spellcheck'
+        | 'icu';
 
-    export enum Validation {
-        EMPTY_STRING_CHECK = 'empty_string_check',
-        EMPTY_SUGGESTION_CHECK = 'empty_suggestion_check',
-        MAX_LENGTH_CHECK = 'max_length_check',
-        TAGS_CHECK = 'tags_check',
-        MISMATCH_IDS_CHECK = 'mismatch_ids_check',
-        CDATA_CHECK = 'cdata_check',
-        SPECIALS_SYMBOLS_CHECK = 'specials_symbols_check',
-        LEADING_NEWLINES_CHECK = 'leading_newlines_check',
-        TRAILING_NEWLINES_CHECK = 'trailing_newlines_check',
-        LEADING_SPACES_CHECK = 'leading_spaces_check',
-        TRAILING_SPACES_CHECK = 'trailing_spaces_check',
-        MULTIPLE_SPACES_CHECK = 'multiple_spaces_check',
-        CUSTOM_BLOCKED_VARIABLES_CHECK = 'custom_blocked_variables_check',
-        HIGHEST_PRIORITY_CUSTOM_VARIABLES_CHECK = 'highest_priority_custom_variables_check',
-        HIGHEST_PRIORITY_VARIABLES_CHECK = 'highest_priority_variables_check',
-        C_VARIABLES_CHECK = 'c_variables_check',
-        PYTHON_VARIABLES_CHECK = 'python_variables_check',
-        RAILS_VARIABLES_CHECK = 'rails_variables_check',
-        JAVA_VARIABLES_CHECK = 'java_variables_check',
-        DOT_NET_VARIABLES_CHECK = 'dot_net_variables_check',
-        TWIG_VARIABLES_CHECK = 'twig_variables_check',
-        PHP_VARIABLES_CHECK = 'php_variables_check',
-        FREEMARKER_VARIABLES_CHECK = 'freemarker_variables_check',
-        LOWEST_PRIORITY_VARIABLE_CHECK = 'lowest_priority_variable_check',
-        LOWEST_PRIORITY_CUSTOM_VARIABLES_CHECK = 'lowest_priority_custom_variables_check',
-        PUNCTUATION_CHECK = 'punctuation_check',
-        SPACES_BEFORE_PUNCTUATION_CHECK = 'spaces_before_punctuation_check',
-        SPACES_AFTER_PUNCTUATION_CHECK = 'spaces_after_punctuation_check',
-        NON_BREAKING_SPACES_CHECK = 'non_breaking_spaces_check',
-        CAPITALIZE_CHECK = 'capitalize_check',
-        MULTIPLE_UPPERCASE_CHECK = 'multiple_uppercase_check',
-        PARENTHESES_CHECK = 'parentheses_check',
-        ENTITIES_CHECK = 'entities_check',
-        ESCAPED_QUOTES_CHECK = 'escaped_quotes_check',
-        WRONG_TRANSLATION_ISSUE_CHECK = 'wrong_translation_issue_check',
-        SPELLCHECK = 'spellcheck',
-        ICU_CHECK = 'icu_check',
-    }
+    export type Validation =
+        | 'empty_string_check'
+        | 'empty_suggestion_check'
+        | 'max_length_check'
+        | 'tags_check'
+        | 'mismatch_ids_check'
+        | 'cdata_check'
+        | 'specials_symbols_check'
+        | 'leading_newlines_check'
+        | 'trailing_newlines_check'
+        | 'leading_spaces_check'
+        | 'trailing_spaces_check'
+        | 'multiple_spaces_check'
+        | 'custom_blocked_variables_check'
+        | 'highest_priority_custom_variables_check'
+        | 'highest_priority_variables_check'
+        | 'c_variables_check'
+        | 'python_variables_check'
+        | 'rails_variables_check'
+        | 'java_variables_check'
+        | 'dot_net_variables_check'
+        | 'twig_variables_check'
+        | 'php_variables_check'
+        | 'freemarker_variables_check'
+        | 'lowest_priority_variable_check'
+        | 'lowest_priority_custom_variables_check'
+        | 'punctuation_check'
+        | 'spaces_before_punctuation_check'
+        | 'spaces_after_punctuation_check'
+        | 'non_breaking_spaces_check'
+        | 'capitalize_check'
+        | 'multiple_uppercase_check'
+        | 'parentheses_check'
+        | 'entities_check'
+        | 'escaped_quotes_check'
+        | 'wrong_translation_issue_check'
+        | 'spellcheck'
+        | 'icu_check';
 
     export interface ListQaCheckIssuesOptions extends PaginationOptions {
         category?: Category;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -209,13 +209,7 @@ export namespace TranslationsModel {
         progress: number;
     }
 
-    export enum BuildStatus {
-        CREATED = 'created',
-        IN_PROGRESS = 'inProgress',
-        CANCELED = 'canceled',
-        FAILED = 'failed',
-        FINISHED = 'finished',
-    }
+    export type BuildStatus = 'created' | 'inProgress' | 'canceled' | 'failed' | 'finished';
 
     export interface BuildProjectFileTranslationRequest {
         targetLanguageId: string;
@@ -243,24 +237,11 @@ export namespace TranslationsModel {
         translateWithPerfectMatchOnly: boolean;
     }
 
-    export enum Method {
-        TM = 'tm',
-        MT = 'mt',
-    }
+    export type Method = 'tm' | 'mt';
 
-    export enum AutoApproveOption {
-        ALL = 'all',
-        EXCEPT_AUTO_SUBSTITUTED = 'exceptAutoSubstituted',
-        PERFECT_MATCH_ONLY = 'perfectMatchOnly',
-        NONE = 'none',
-    }
+    export type AutoApproveOption = 'all' | 'exceptAutoSubstituted' | 'perfectMatchOnly' | 'none';
 
-    export enum CharTransformation {
-        ASIAN = 'asian',
-        EUROPEAN = 'european',
-        ARABIC = 'arabic',
-        CYRILLIC = 'cyrillic',
-    }
+    export type CharTransformation = 'asian' | 'european' | 'arabic' | 'cyrillic';
 
     export interface Build {
         id: number;

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -192,16 +192,9 @@ export namespace UsersModel {
         timezone: string;
     }
 
-    export enum Status {
-        ACTIVE = 'active',
-        PENDING = 'pending',
-        BLOCKED = 'blocked',
-    }
+    export type Status = 'active' | 'pending' | 'blocked';
 
-    export enum TwoFactor {
-        ENABLED = 'enabled',
-        DISABLED = 'disabled',
-    }
+    export type TwoFactor = 'enabled' | 'disabled';
 
     export interface ProjectMember {
         id: number;
@@ -237,20 +230,9 @@ export namespace UsersModel {
         name: string;
     }
 
-    export enum Role {
-        ALL = 'all',
-        OWNER = 'owner',
-        MANAGER = 'manager',
-        PROOFREADER = 'proofreader',
-        TRANSLATOR = 'translator',
-        BLOCKED = 'blocked',
-    }
+    export type Role = 'all' | 'owner' | 'manager' | 'proofreader' | 'translator' | 'blocked';
 
-    export enum LanguageRole {
-        PROOFREADER = 'proofreader',
-        TRANSLATOR = 'translator',
-        DENIED = 'denied',
-    }
+    export type LanguageRole = 'proofreader' | 'translator' | 'denied';
 
     export interface AddProjectMemberRequest {
         userIds: number[];

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -106,27 +106,19 @@ export namespace WebhooksModel {
         payload?: any;
     }
 
-    export enum ContentType {
-        MULTIPART_FORM_DATA = 'multipart/form-data',
-        APPLICATION_JSON = 'application/json',
-        APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded',
-    }
+    export type ContentType = 'multipart/form-data' | 'application/json' | 'application/x-www-form-urlencoded';
 
-    export enum Event {
-        FILE_TRANSLATED = 'file.translated',
-        FILE_APPROVED = 'file.approved',
-        PROJECT_TRANSLATED = 'project.translated',
-        PROJECT_APPROVED = 'project.approved',
-        TRANSLATION_UPDATED = 'translation.updated',
-        SUGGESTION_ADDED = 'suggestion.added',
-        SUGGESTION_UPDATED = 'suggestion.updated',
-        SUGGESTION_DELETED = 'suggestion.deleted',
-        SUGGESTION_APPROVED = 'suggestion.approved',
-        SUGGESTION_DISAPPROVED = 'suggestion.disapproved',
-    }
+    export type Event =
+        | 'file.translated'
+        | 'file.approved'
+        | 'project.translated'
+        | 'project.approved'
+        | 'translation.updated'
+        | 'suggestion.added'
+        | 'suggestion.updated'
+        | 'suggestion.deleted'
+        | 'suggestion.approved'
+        | 'suggestion.disapproved';
 
-    export enum RequestType {
-        POST = 'POST',
-        GET = 'GET',
-    }
+    export type RequestType = 'POST' | 'GET';
 }

--- a/tests/dictionaries/api.test.ts
+++ b/tests/dictionaries/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Dictionaries, PatchOperation } from '../../src';
+import { Credentials, Dictionaries } from '../../src';
 
 describe('Dictionaries API', () => {
     let scope: nock.Scope;
@@ -40,7 +40,7 @@ describe('Dictionaries API', () => {
                 `/projects/${projectId}/dictionaries/${languageId}`,
                 [
                     {
-                        op: PatchOperation.REMOVE,
+                        op: 'remove',
                         path: '/words/0',
                     },
                 ],
@@ -75,7 +75,7 @@ describe('Dictionaries API', () => {
     it('Edit Dictionary', async () => {
         const dictionary = await api.editDictionary(projectId, languageId, [
             {
-                op: PatchOperation.REMOVE,
+                op: 'remove',
                 path: '/words/0',
             },
         ]);

--- a/tests/distributions/api.test.ts
+++ b/tests/distributions/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Distributions, PatchOperation } from '../../src';
+import { Credentials, Distributions } from '../../src';
 
 describe('Distributions API', () => {
     let scope: nock.Scope;
@@ -71,7 +71,7 @@ describe('Distributions API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -140,7 +140,7 @@ describe('Distributions API', () => {
     it('Edit distribution', async () => {
         const distribution = await api.editDistribution(projectId, hash, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: name,
             },

--- a/tests/glossaries/api.test.ts
+++ b/tests/glossaries/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Glossaries, GlossariesModel, PatchOperation } from '../../src/index';
+import { Credentials, Glossaries } from '../../src/index';
 
 describe('Glossaries API', () => {
     let scope: nock.Scope;
@@ -11,7 +11,7 @@ describe('Glossaries API', () => {
     const glossaryId = 112;
     const glossaryName = 'test';
     const glossaryTerms = 4;
-    const glossaryFormat = GlossariesModel.GlossaryFormat.CSV;
+    const glossaryFormat = 'csv';
     const glossaryLink = 'test.com';
     const exportId = '1111';
     const importId = '2222';
@@ -87,7 +87,7 @@ describe('Glossaries API', () => {
                 [
                     {
                         value: glossaryTerms,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/term',
                     },
                 ],
@@ -236,7 +236,7 @@ describe('Glossaries API', () => {
                 [
                     {
                         value: termText,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/text',
                     },
                 ],
@@ -290,7 +290,7 @@ describe('Glossaries API', () => {
     it('Edit glossary', async () => {
         const glossary = await api.editGlossary(glossaryId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/term',
                 value: glossaryTerms,
             },
@@ -364,7 +364,7 @@ describe('Glossaries API', () => {
     it('Edit term', async () => {
         const term = await api.editTerm(glossaryId, termId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/text',
                 value: termText,
             },

--- a/tests/issues/api.test.ts
+++ b/tests/issues/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Issues, PatchOperation, IssuesModel } from '../../src';
+import { Credentials, Issues } from '../../src';
 
 describe('Issues API', () => {
     let scope: nock.Scope;
@@ -37,8 +37,8 @@ describe('Issues API', () => {
                 `/projects/${projectId}/issues/${issueId}`,
                 [
                     {
-                        value: IssuesModel.Status.UNRESOLVED,
-                        op: PatchOperation.REPLACE,
+                        value: 'unresolved',
+                        op: 'replace',
                         path: '/status',
                     },
                 ],
@@ -51,7 +51,7 @@ describe('Issues API', () => {
             .reply(200, {
                 data: {
                     id: issueId,
-                    status: IssuesModel.Status.UNRESOLVED,
+                    status: 'unresolved',
                 },
             });
     });
@@ -70,12 +70,12 @@ describe('Issues API', () => {
     it('Edit issue', async () => {
         const issue = await api.editIssue(projectId, issueId, [
             {
-                value: IssuesModel.Status.UNRESOLVED,
-                op: PatchOperation.REPLACE,
+                value: 'unresolved',
+                op: 'replace',
                 path: '/status',
             },
         ]);
         expect(issue.data.id).toBe(issueId);
-        expect(issue.data.status).toBe(IssuesModel.Status.UNRESOLVED);
+        expect(issue.data.status).toBe('unresolved');
     });
 });

--- a/tests/labels/api.test.ts
+++ b/tests/labels/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Labels, PatchOperation } from '../../src/index';
+import { Credentials, Labels } from '../../src/index';
 
 describe('Labels API', () => {
     let scope: nock.Scope;
@@ -72,7 +72,7 @@ describe('Labels API', () => {
                 [
                     {
                         value: title,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -165,7 +165,7 @@ describe('Labels API', () => {
     it('Edit label', async () => {
         const label = await api.editLabel(projectId, labelId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: title,
             },

--- a/tests/languages/api.test.ts
+++ b/tests/languages/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Languages, PatchOperation, LanguagesModel } from '../../src';
+import { Credentials, Languages } from '../../src';
 
 describe('Languages API', () => {
     let scope: nock.Scope;
@@ -13,7 +13,7 @@ describe('Languages API', () => {
     const code = '12';
     const localeCode = 't';
     const threeLettersCode = 'tst';
-    const textDirection = LanguagesModel.TextDirection.LTR;
+    const textDirection = 'ltr';
 
     const limit = 25;
 
@@ -79,7 +79,7 @@ describe('Languages API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -133,7 +133,7 @@ describe('Languages API', () => {
         const language = await api.editCustomLanguage(languageId, [
             {
                 value: name,
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
             },
         ]);

--- a/tests/machineTranslation/api.test.ts
+++ b/tests/machineTranslation/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, MachineTranslation, PatchOperation } from '../../src';
+import { Credentials, MachineTranslation } from '../../src';
 
 describe('Machine Translation engines (MTs) API', () => {
     let scope: nock.Scope;
@@ -78,7 +78,7 @@ describe('Machine Translation engines (MTs) API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -144,7 +144,7 @@ describe('Machine Translation engines (MTs) API', () => {
     it('Update MT', async () => {
         const mt = await api.updateMt(mtId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: name,
             },

--- a/tests/projectsGroups/api.test.ts
+++ b/tests/projectsGroups/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, ProjectsGroups } from '../../src';
+import { Credentials, ProjectsGroups } from '../../src';
 
 describe('Projects and Groups API', () => {
     let scope: nock.Scope;
@@ -73,7 +73,7 @@ describe('Projects and Groups API', () => {
                 [
                     {
                         value: groupName,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -149,7 +149,7 @@ describe('Projects and Groups API', () => {
                 [
                     {
                         value: projectName,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -197,7 +197,7 @@ describe('Projects and Groups API', () => {
     it('Edit group', async () => {
         const group = await api.editGroup(groupId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: groupName,
             },
@@ -237,7 +237,7 @@ describe('Projects and Groups API', () => {
     it('Edit project', async () => {
         const project = await api.editProject(projectId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: projectName,
             },

--- a/tests/reports/api.test.ts
+++ b/tests/reports/api.test.ts
@@ -14,13 +14,13 @@ describe('Reports API', () => {
     const reportName = 'testReport';
     const downloadLink = 'test.com';
     const schema: ReportsModel.TopMembersSchema = {
-        unit: ReportsModel.Unit.CHARS,
-        format: ReportsModel.Format.CSV,
+        unit: 'chars',
+        format: 'csv',
         languageId: 'fr',
     };
     const groupSchema: ReportsModel.GroupTopMembersSchema = {
-        format: ReportsModel.Format.JSON,
-        groupBy: ReportsModel.GroupBy.LANGUAGE,
+        format: 'json',
+        groupBy: 'language',
         projectIds: [projectId],
     };
 

--- a/tests/screenshots/api.test.ts
+++ b/tests/screenshots/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, Screenshots } from '../../src';
+import { Credentials, Screenshots } from '../../src';
 
 describe('Screenshots API', () => {
     let scope: nock.Scope;
@@ -96,7 +96,7 @@ describe('Screenshots API', () => {
                 [
                     {
                         value: screenshotName,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -192,7 +192,7 @@ describe('Screenshots API', () => {
                 [
                     {
                         value: stringId,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/stringId',
                     },
                 ],
@@ -252,7 +252,7 @@ describe('Screenshots API', () => {
     it('Edit screenshot', async () => {
         const screenshot = await api.editScreenshot(projectId, screenshotId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: screenshotName,
             },
@@ -304,7 +304,7 @@ describe('Screenshots API', () => {
     it('Update tag', async () => {
         const tag = await api.updateTag(projectId, screenshotId, tagId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/stringId',
                 value: stringId,
             },

--- a/tests/sourceFiles/api.test.ts
+++ b/tests/sourceFiles/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, SourceFiles } from '../../src';
+import { Credentials, SourceFiles } from '../../src';
 
 describe('Source Files API', () => {
     let scope: nock.Scope;
@@ -92,7 +92,7 @@ describe('Source Files API', () => {
                 [
                     {
                         value: branchTitle,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -167,7 +167,7 @@ describe('Source Files API', () => {
                 [
                     {
                         value: directoryTitle,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -260,7 +260,7 @@ describe('Source Files API', () => {
                 [
                     {
                         value: fileTitle,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -414,7 +414,7 @@ describe('Source Files API', () => {
     it('Edit branch', async () => {
         const branch = await api.editBranch(projectId, branchId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: branchTitle,
             },
@@ -453,7 +453,7 @@ describe('Source Files API', () => {
     it('Edit directory', async () => {
         const directory = await api.editDirectory(projectId, directoryId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: directoryTitle,
             },
@@ -499,7 +499,7 @@ describe('Source Files API', () => {
     it('Edit file', async () => {
         const file = await api.editFile(projectId, fileId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: fileTitle,
             },

--- a/tests/sourceStrings/api.test.ts
+++ b/tests/sourceStrings/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, SourceStrings } from '../../src';
+import { Credentials, SourceStrings } from '../../src';
 
 describe('Source Strings API', () => {
     let scope: nock.Scope;
@@ -76,7 +76,7 @@ describe('Source Strings API', () => {
                 [
                     {
                         value: stringText,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/text',
                     },
                 ],
@@ -128,7 +128,7 @@ describe('Source Strings API', () => {
     it('Edit string', async () => {
         const string = await api.editString(projectId, stringId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/text',
                 value: stringText,
             },

--- a/tests/stringComments/api.test.ts
+++ b/tests/stringComments/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, StringComments, StringCommentsModel } from '../../src/index';
+import { Credentials, StringComments } from '../../src/index';
 
 describe('String Comments API', () => {
     let scope: nock.Scope;
@@ -13,7 +13,7 @@ describe('String Comments API', () => {
     const stringCommentId = 4;
     const text = 'test';
     const languageId = 'uk';
-    const type = StringCommentsModel.Type.COMMENT;
+    const type = 'comment';
 
     const limit = 25;
 
@@ -80,7 +80,7 @@ describe('String Comments API', () => {
                 [
                     {
                         value: type,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/type',
                     },
                 ],
@@ -131,7 +131,7 @@ describe('String Comments API', () => {
     it('Edit string comment', async () => {
         const comment = await api.editStringComment(projectId, stringCommentId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/type',
                 value: type,
             },

--- a/tests/stringTranslations/api.test.ts
+++ b/tests/stringTranslations/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, StringTranslations, StringTranslationsModel } from '../../src';
+import { Credentials, StringTranslations } from '../../src';
 
 describe('String Translations API', () => {
     let scope: nock.Scope;
@@ -15,7 +15,7 @@ describe('String Translations API', () => {
     const languageId = 'fr';
     const text = 'test';
     const voteId = 1234;
-    const mark = StringTranslationsModel.Mark.DOWN;
+    const mark = 'down';
 
     const limit = 25;
 

--- a/tests/tasks/api.test.ts
+++ b/tests/tasks/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, Tasks } from '../../src';
+import { Credentials, Tasks } from '../../src';
 
 describe('Tasks API', () => {
     let scope: nock.Scope;
@@ -97,7 +97,7 @@ describe('Tasks API', () => {
                 [
                     {
                         value: taskTitle,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -136,7 +136,7 @@ describe('Tasks API', () => {
                 [
                     {
                         value: taskTitle,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/title',
                     },
                 ],
@@ -197,7 +197,7 @@ describe('Tasks API', () => {
     it('Edit task', async () => {
         const task = await api.editTask(projectId, taskId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: taskTitle,
             },
@@ -216,7 +216,7 @@ describe('Tasks API', () => {
     it('Edit Task Archived Status', async () => {
         const task = await api.editTaskArchivedStatus(projectId, taskId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/title',
                 value: taskTitle,
             },

--- a/tests/teams/api.test.ts
+++ b/tests/teams/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, Teams } from '../../src';
+import { Credentials, Teams } from '../../src';
 
 describe('Tasks API', () => {
     let scope: nock.Scope;
@@ -88,7 +88,7 @@ describe('Tasks API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -191,7 +191,7 @@ describe('Tasks API', () => {
     it('Edit team', async () => {
         const team = await api.editTeam(teamId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: name,
             },

--- a/tests/translationMemory/api.test.ts
+++ b/tests/translationMemory/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, PatchOperation, TranslationMemory } from '../../src';
+import { Credentials, TranslationMemory } from '../../src';
 
 describe('Translation Memory API', () => {
     let scope: nock.Scope;
@@ -81,7 +81,7 @@ describe('Translation Memory API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -197,7 +197,7 @@ describe('Translation Memory API', () => {
     it('Update TM', async () => {
         const tm = await api.editTm(tmId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: name,
             },

--- a/tests/webhooks/api.test.ts
+++ b/tests/webhooks/api.test.ts
@@ -1,5 +1,5 @@
 import * as nock from 'nock';
-import { Credentials, Webhooks, WebhooksModel, PatchOperation } from '../../src/index';
+import { Credentials, Webhooks } from '../../src/index';
 
 describe('Web-hooks API', () => {
     let scope: nock.Scope;
@@ -12,7 +12,7 @@ describe('Web-hooks API', () => {
     const webhookId = 3;
     const name = 'test';
     const url = 'test.com';
-    const requestType = WebhooksModel.RequestType.GET;
+    const requestType = 'GET';
 
     const limit = 25;
 
@@ -76,7 +76,7 @@ describe('Web-hooks API', () => {
                 [
                     {
                         value: name,
-                        op: PatchOperation.REPLACE,
+                        op: 'replace',
                         path: '/name',
                     },
                 ],
@@ -127,7 +127,7 @@ describe('Web-hooks API', () => {
     it('Edit webhook', async () => {
         const webhook = await api.editWebhook(projectId, webhookId, [
             {
-                op: PatchOperation.REPLACE,
+                op: 'replace',
                 path: '/name',
                 value: name,
             },


### PR DESCRIPTION
This PR replaces all string enums with string type declarations. This is a much needed breaking change as these enums never behaved like they were supposed to, and caused type errors when users didn't wanna use the enum values and wanted to type the strings themselves, which is equally valid and much more practical. This also gives users intellisense when typing properties with these types as it will give them a list of words they can choose from, and error out if they don't choose any of those.

This is another part of #137 but that is still not done, however, any release after this PR is merged will need to be a major version release so I'd like to ask you to hold off releases for now until everything in that issue has been achieved: mostly splitting the code up into enterprise and regular API classes.