### PR TITLE
fix(AxiosProvider): fix typo in name

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,4 @@
-import { AxisProvider } from './internal/axios/axiosProvider';
+import { AxiosProvider } from './internal/axios/axiosProvider';
 import { FetchClient } from './internal/fetch/fetchClient';
 import { RetryConfig, RetryService } from './internal/retry';
 
@@ -110,7 +110,7 @@ export interface Attribute {
 
 export abstract class CrowdinApi {
     private static readonly CROWDIN_URL_SUFFIX: string = 'api.crowdin.com/api/v2';
-    private static readonly AXIOS_INSTANCE = new AxisProvider().axios;
+    private static readonly AXIOS_INSTANCE = new AxiosProvider().axios;
     private static readonly FETCH_INSTANCE = new FetchClient();
 
     readonly token: string;

--- a/src/core/internal/axios/axiosProvider.ts
+++ b/src/core/internal/axios/axiosProvider.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { CommonErrorResponse, ValidationErrorResponse } from '../..';
 
-export class AxisProvider {
+export class AxiosProvider {
     private static readonly CROWDIN_API_MAX_CONCURRENT_REQUESTS = 15;
     private static readonly CROWDIN_API_REQUESTS_INTERVAL_MS = 10;
 
@@ -18,12 +18,12 @@ export class AxisProvider {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             return new Promise(resolve => {
                 const interval = setInterval(() => {
-                    if (this.pendingRequests < AxisProvider.CROWDIN_API_MAX_CONCURRENT_REQUESTS) {
+                    if (this.pendingRequests < AxiosProvider.CROWDIN_API_MAX_CONCURRENT_REQUESTS) {
                         this.pendingRequests++;
                         clearInterval(interval);
                         resolve(config);
                     }
-                }, AxisProvider.CROWDIN_API_REQUESTS_INTERVAL_MS);
+                }, AxiosProvider.CROWDIN_API_REQUESTS_INTERVAL_MS);
             });
         });
     }


### PR DESCRIPTION
This PR simply fixes a typo in the name of the class "AxiosProvider". This can be considered non-breaking and thus semver: patch as the class is only used in private properties and not exported. This, however, doesn't need a release since it's such a minor change