### PR TITLE
fix: don't emit deprecation warn when argument is absent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
         "curly": 2,
 		"semi": 2,
 		"brace-style": 2,
-        "quotes": [2, "single", "avoid-escape"]
+        "quotes": [2, "single", "avoid-escape"],
+        "prefer-rest-params": "off"
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -301,18 +301,28 @@ function emitDeprecationWarning(): void {
     }
 }
 
-export function isOptionalString(parameter?: string | unknown): parameter is string | undefined {
+export function isOptionalString(
+    parameter: string | unknown,
+    parameterInArgs: boolean,
+): parameter is string | undefined {
     if (typeof parameter === 'string' || typeof parameter === 'undefined') {
-        emitDeprecationWarning();
+        if (parameterInArgs) {
+            emitDeprecationWarning();
+        }
         return true;
     } else {
         return false;
     }
 }
 
-export function isOptionalNumber(parameter?: number | unknown): parameter is number | undefined {
+export function isOptionalNumber(
+    parameter: number | unknown,
+    parameterInArgs: boolean,
+): parameter is number | undefined {
     if (typeof parameter === 'number' || typeof parameter === 'undefined') {
-        emitDeprecationWarning();
+        if (parameterInArgs) {
+            emitDeprecationWarning();
+        }
         return true;
     } else {
         return false;

--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -21,7 +21,7 @@ export class Dictionaries extends CrowdinApi {
         projectId: number,
         options?: string | DictionariesModel.ListDictionariesOptions,
     ): Promise<ResponseList<DictionariesModel.Dictionary>> {
-        if (isOptionalString(options)) {
+        if (isOptionalString(options, '1' in arguments)) {
             options = { languageIds: options };
         }
         let url = `${this.url}/projects/${projectId}/dictionaries`;

--- a/src/distributions/index.ts
+++ b/src/distributions/index.ts
@@ -27,7 +27,7 @@ export class Distributions extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<DistributionsModel.Distribution>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/distributions`;

--- a/src/glossaries/index.ts
+++ b/src/glossaries/index.ts
@@ -28,7 +28,7 @@ export class Glossaries extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<GlossariesModel.Glossary>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/glossaries`;
@@ -171,7 +171,7 @@ export class Glossaries extends CrowdinApi {
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseList<GlossariesModel.Term>> {
         let url = `${this.url}/glossaries/${glossaryId}/terms`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 userId: options,
                 limit: deprecatedLimit,
@@ -225,7 +225,7 @@ export class Glossaries extends CrowdinApi {
         options?: number | GlossariesModel.ClearGlossaryOptions,
         deprecatedTranslationOfTermId?: number,
     ): Promise<ResponseObject<GlossariesModel.Term>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { languageId: options, translationOfTermId: deprecatedTranslationOfTermId };
         }
         let url = `${this.url}/glossaries/${glossaryId}/terms`;

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -36,7 +36,7 @@ export class Issues extends CrowdinApi {
         deprecatedType?: IssuesModel.Type,
         deprecatedStatus?: IssuesModel.Status,
     ): Promise<ResponseList<IssuesModel.Issue>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -21,7 +21,7 @@ export class Labels extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LabelsModel.Label>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/labels`;

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -17,7 +17,7 @@ export class Languages extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<LanguagesModel.Language>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/languages`;

--- a/src/machineTranslation/index.ts
+++ b/src/machineTranslation/index.ts
@@ -25,7 +25,7 @@ export class MachineTranslation extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<MachineTranslationModel.MachineTranslation>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/mts`;

--- a/src/projectsGroups/index.ts
+++ b/src/projectsGroups/index.ts
@@ -35,7 +35,7 @@ export class ProjectsGroups extends CrowdinApi {
         deprecatedUserId?: number,
         deprecatedLimit?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Group>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = {
                 parentId: options,
                 offset: deprecatedOffset,
@@ -113,7 +113,7 @@ export class ProjectsGroups extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ProjectsGroupsModel.Project | ProjectsGroupsModel.ProjectSettings>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = {
                 groupId: options,
                 hasManagerAccess: deprecatedHasManagerAccess,

--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -24,7 +24,7 @@ export class Screenshots extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Screenshot>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/screenshots`;
@@ -125,7 +125,7 @@ export class Screenshots extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<ScreenshotsModel.Tag>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/screenshots/${screenshotId}/tags`;

--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -39,7 +39,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.Branch>> {
-        if (isOptionalString(options)) {
+        if (isOptionalString(options, '1' in arguments)) {
             options = { name: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/projects/${projectId}/branches`;
@@ -134,7 +134,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedRecursion?: string,
     ): Promise<ResponseList<SourceFilesModel.Directory>> {
         let url = `${this.url}/projects/${projectId}/directories`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -238,7 +238,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedFilter?: string,
     ): Promise<ResponseList<SourceFilesModel.File>> {
         let url = `${this.url}/projects/${projectId}/files`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 branchId: options,
                 directoryId: deprecatedDirectoryId,
@@ -359,7 +359,7 @@ export class SourceFiles extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.FileRevision>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/revisions`;
@@ -410,7 +410,7 @@ export class SourceFiles extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<SourceFilesModel.ReviewedSourceFilesBuild>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/projects/${projectId}/strings/reviewed-builds`;

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -60,7 +60,7 @@ export class SourceStrings extends CrowdinApi {
         deprecatedDirectoryId?: number,
     ): Promise<ResponseList<SourceStringsModel.String>> {
         let url = `${this.url}/projects/${projectId}/strings`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 fileId: options,
                 limit: deprecatedLimit,

--- a/src/stringComments/index.ts
+++ b/src/stringComments/index.ts
@@ -38,7 +38,7 @@ export class StringComments extends CrowdinApi {
         deprecatedIssueStatus?: StringCommentsModel.IssueStatus,
     ): Promise<ResponseList<StringCommentsModel.StringComment>> {
         let url = `${this.url}/projects/${projectId}/comments`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 stringId: options,
                 type: deprecatedType,

--- a/src/stringTranslations/index.ts
+++ b/src/stringTranslations/index.ts
@@ -48,7 +48,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedFileId?: number,
     ): Promise<ResponseList<StringTranslationsModel.Approval>> {
         let url = `${this.url}/projects/${projectId}/approvals`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,
@@ -163,7 +163,7 @@ export class StringTranslations extends CrowdinApi {
         >
     > {
         let url = `${this.url}/projects/${projectId}/languages/${languageId}/translations`;
-        if (isOptionalString(options)) {
+        if (isOptionalString(options, '2' in arguments)) {
             options = {
                 stringIds: options,
                 fileId,
@@ -221,7 +221,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedDenormalizePlaceholders?: BooleanInt,
     ): Promise<ResponseList<StringTranslationsModel.StringTranslation>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '3' in arguments)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,
@@ -333,7 +333,7 @@ export class StringTranslations extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<StringTranslationsModel.Vote>> {
         let url = `${this.url}/projects/${projectId}/votes`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 stringId: options,
                 languageId: deprecatedLanguageId,

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -36,7 +36,7 @@ export class Tasks extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedStatus?: TasksModel.Status,
     ): Promise<ResponseList<TasksModel.Task>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset, status: deprecatedStatus };
         }
         let url = `${this.url}/projects/${projectId}/tasks`;
@@ -129,7 +129,7 @@ export class Tasks extends CrowdinApi {
         deprecatedIsArchived?: BooleanInt,
     ): Promise<ResponseList<TasksModel.UserTask>> {
         let url = `${this.url}/user/tasks`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -35,7 +35,7 @@ export class Teams extends CrowdinApi {
      */
     listTeams(limit?: number, offset?: number): Promise<ResponseList<TeamsModel.Team>>;
     listTeams(options?: number | PaginationOptions, deprecatedOffset?: number): Promise<ResponseList<TeamsModel.Team>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/teams`;
@@ -98,7 +98,7 @@ export class Teams extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TeamsModel.TeamMember>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/teams/${teamId}/members`;

--- a/src/translationMemory/index.ts
+++ b/src/translationMemory/index.ts
@@ -34,7 +34,7 @@ export class TranslationMemory extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationMemoryModel.TranslationMemory>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/tms`;

--- a/src/translationStatus/index.ts
+++ b/src/translationStatus/index.ts
@@ -32,7 +32,7 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/branches/${branchId}/languages/progress`;
@@ -70,7 +70,7 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}/languages/progress`;
@@ -108,7 +108,7 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/files/${fileId}/languages/progress`;
@@ -146,7 +146,7 @@ export class TranslationStatus extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationStatusModel.FileProgress>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '2' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/languages/${languageId}/progress`;
@@ -182,7 +182,7 @@ export class TranslationStatus extends CrowdinApi {
         deprecatedOffset?: number,
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.LanguageProgress>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset, languageIds: deprecatedLanguageIds };
         }
         let url = `${this.url}/projects/${projectId}/languages/progress`;
@@ -226,7 +226,7 @@ export class TranslationStatus extends CrowdinApi {
         deprecatedLanguageIds?: string,
     ): Promise<ResponseList<TranslationStatusModel.QaCheck>> {
         let url = `${this.url}/projects/${projectId}/qa-checks`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = {
                 limit: options,
                 offset: deprecatedOffset,

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -101,7 +101,7 @@ export class Translations extends CrowdinApi {
         deprecatedLimit?: number,
         deprecatedOffset?: number,
     ): Promise<ResponseList<TranslationsModel.Build>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { branchId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         let url = `${this.url}/projects/${projectId}/translations/builds`;

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -927,7 +927,7 @@ export class UploadStorage extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<UploadStorageModel.Storage>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/storages`;

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -37,7 +37,7 @@ export class Users extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.ProjectMember | UsersModel.EnterpriseProjectMember>> {
         let url = `${this.url}/projects/${projectId}/members`;
-        if (isOptionalString(options)) {
+        if (isOptionalString(options, '1' in arguments)) {
             options = {
                 search: options,
                 role: deprecatedRole,
@@ -131,7 +131,7 @@ export class Users extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<UsersModel.User>> {
         let url = `${this.url}/users`;
-        if (isOptionalString(options)) {
+        if (isOptionalString(options, '0' in arguments)) {
             options = {
                 status: options,
                 search: deprecatedSearch,

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -17,7 +17,7 @@ export class Vendors extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<VendorsModel.Vendor>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/vendors`;

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -20,7 +20,7 @@ export class Webhooks extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WebhooksModel.Webhook>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/webhooks`;

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -27,7 +27,7 @@ export class Workflows extends CrowdinApi {
         options?: number | PaginationOptions,
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.ListWorkflowStepsResponse>> {
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '1' in arguments)) {
             options = { limit: options, offset: deprecatedOffset };
         }
         const url = `${this.url}/projects/${projectId}/workflow-steps`;
@@ -72,7 +72,7 @@ export class Workflows extends CrowdinApi {
         deprecatedOffset?: number,
     ): Promise<ResponseList<WorkflowModel.Workflow>> {
         let url = `${this.url}/workflow-templates`;
-        if (isOptionalNumber(options)) {
+        if (isOptionalNumber(options, '0' in arguments)) {
             options = { groupId: options, limit: deprecatedLimit, offset: deprecatedOffset };
         }
         url = this.addQueryParam(url, 'groupId', options.groupId);


### PR DESCRIPTION
So it turns out that #150 introduced a bug where if you left out optional parameters you'd get a deprecation warning. This PR fixes it by checking if the argument was passed to the function and only emits the warning if so. The solution isn't ideal but it's the best thing I found so please let me know if you have better ideas