### PR TITLE
fix: optionalize identifier

### DIFF
--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -168,7 +168,7 @@ export namespace SourceStringsModel {
     }
 
     export interface CreateStringRequest {
-        identifier: string;
+        identifier?: string;
         fileId?: number;
         text: string;
         context?: string;


### PR DESCRIPTION
# Problem

Identifier should be optional:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/1003261/159976904-f1c8adcc-8aa4-4781-9627-dca6a4989e47.png">

But is marked as required in TypeScript

# Solution

Make the field optional