### PR TITLE
#188 - Encode the Crowdin-API-FileName

### DIFF
--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -955,7 +955,7 @@ export class UploadStorage extends CrowdinApi {
     ): Promise<ResponseObject<UploadStorageModel.Storage>> {
         const url = `${this.url}/storages`;
         const config = this.defaultConfig();
-        config.headers['Crowdin-API-FileName'] = fileName;
+        config.headers['Crowdin-API-FileName'] = this.urlEncodeFileName(fileName);
         if (contentType) {
             config.headers['Content-Type'] = contentType;
         } else {
@@ -968,6 +968,13 @@ export class UploadStorage extends CrowdinApi {
             config.headers['Content-Type'] = contentType ?? 'application/octet-stream';
         }
         return this.post(url, request, config);
+    }
+
+    /**
+     * @param fileName file name
+     */
+    urlEncodeFileName(fileName: string): string {
+        return encodeURIComponent(fileName);
     }
 
     /**

--- a/tests/uploadStorage/api.test.ts
+++ b/tests/uploadStorage/api.test.ts
@@ -10,6 +10,7 @@ describe('Upload Storage API', () => {
     const api: UploadStorage = new UploadStorage(credentials);
     const storageId = 2;
     const fileName = 'words.txt';
+    const urlEncodedFileName = encodeURIComponent(fileName);
     const fileContent = 'test text.';
 
     const limit = 25;
@@ -36,7 +37,7 @@ describe('Upload Storage API', () => {
             })
             .post('/storages', fileContent, {
                 reqheaders: {
-                    'Crowdin-API-FileName': fileName,
+                    'Crowdin-API-FileName': urlEncodedFileName,
                     Authorization: `Bearer ${api.token}`,
                 },
             })
@@ -86,5 +87,11 @@ describe('Upload Storage API', () => {
 
     it('Delete storage', async () => {
         await api.deleteStorage(storageId);
+    });
+
+    it('URL encodes the filename', async () => {
+        const fileName = 'Беларусь';
+        const urlEncodeFileName = api.urlEncodeFileName(fileName);
+        expect(urlEncodeFileName).toBe('%D0%91%D0%B5%D0%BB%D0%B0%D1%80%D1%83%D1%81%D1%8C');
     });
 });

--- a/tests/uploadStorage/api.test.ts
+++ b/tests/uploadStorage/api.test.ts
@@ -89,9 +89,15 @@ describe('Upload Storage API', () => {
         await api.deleteStorage(storageId);
     });
 
-    it('URL encodes the filename', async () => {
+    it('URL encodes a Cyrillic filename', async () => {
         const fileName = 'абвгд';
         const urlEncodeFileName = api.urlEncodeFileName(fileName);
         expect(urlEncodeFileName).toBe('%D0%B0%D0%B1%D0%B2%D0%B3%D0%B4');
+    });
+
+    it('URL encodes a non-Cyrillic filename', async () => {
+        const fileName = 'filename';
+        const urlEncodeFileName = api.urlEncodeFileName(fileName);
+        expect(urlEncodeFileName).toBe('filename');
     });
 });

--- a/tests/uploadStorage/api.test.ts
+++ b/tests/uploadStorage/api.test.ts
@@ -90,8 +90,8 @@ describe('Upload Storage API', () => {
     });
 
     it('URL encodes the filename', async () => {
-        const fileName = 'Беларусь';
+        const fileName = 'абвгд';
         const urlEncodeFileName = api.urlEncodeFileName(fileName);
-        expect(urlEncodeFileName).toBe('%D0%91%D0%B5%D0%BB%D0%B0%D1%80%D1%83%D1%81%D1%8C');
+        expect(urlEncodeFileName).toBe('%D0%B0%D0%B1%D0%B2%D0%B3%D0%B4');
     });
 });


### PR DESCRIPTION
Encoded the Crowdin-API-FileName header value according to the [documentation](https://developer.crowdin.com/api/v2/#operation/api.storages.post).

Also added a test case to test the method that encoded the value.