### PR TITLE
Updated Dependabot.yml to fix registry error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.WORKFLOWS_TOKEN}}
 updates:
   - package-ecosystem: "npm" # See documentation for possible values 
     directory: "/" # Location of package manifests


### PR DESCRIPTION
Thought the top level registries key was optional and so skipped it the first time. 
Should be fine this time. 

Reference  - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-private-registries
