### PR TITLE
Fix: storage upload for string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@crowdin/crowdin-api-client",
-    "version": "1.21.1",
+    "version": "1.21.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@crowdin/crowdin-api-client",
-            "version": "1.21.1",
+            "version": "1.21.2",
             "license": "MIT",
             "dependencies": {
                 "axios": "0.21.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crowdin/crowdin-api-client",
-    "version": "1.21.1",
+    "version": "1.21.2",
     "description": "JavaScript library for Crowdin API v2.",
     "main": "out/index.js",
     "types": "out/index.d.ts",

--- a/src/uploadStorage/index.ts
+++ b/src/uploadStorage/index.ts
@@ -958,6 +958,8 @@ export class UploadStorage extends CrowdinApi {
         config.headers['Crowdin-API-FileName'] = this.encodeUrlParam(fileName);
         if (contentType) {
             config.headers['Content-Type'] = contentType;
+        } else if (typeof request === 'string') {
+            config.headers['Content-Type'] = 'text/plain';
         } else {
             const fileNameParts = fileName.split('.');
             let contentType;


### PR DESCRIPTION
Fix for `addStorage` to pass file content as string

```js
const contentString = fs.readFileSync(file, 'utf8');
const contentBuffer = fs.readFileSync(file);
//both options now will produce file with correct type
await client.uploadStorageApi.addStorage(file, contentBuffer);
//or
await client.uploadStorageApi.addStorage(file, contentString);
```