### PR TITLE
feat: Apply Pre-Translation API: add labels support

### DIFF
--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -198,6 +198,8 @@ export namespace TranslationsModel {
         translateUntranslatedOnly?: boolean;
         translateWithPerfectMatchOnly?: boolean;
         markAddedTranslationsAsDone?: boolean;
+        labelIds?: number[];
+        excludeLabelIds?: number[];
     }
 
     export interface BuildProjectDirectoryTranslationRequest {
@@ -241,6 +243,8 @@ export namespace TranslationsModel {
         duplicateTranslations: boolean;
         translateUntranslatedOnly: boolean;
         translateWithPerfectMatchOnly: boolean;
+        labelIds?: number[];
+        excludeLabelIds?: number[];
     }
 
     export type Method = 'tm' | 'mt';

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -21,7 +21,6 @@ describe('Translations API', () => {
     const sampleLabelIds = [101, 102];
     const sampleExcludeLabelIds = [103, 104];
 
-
     const limit = 25;
 
     beforeAll(() => {
@@ -199,8 +198,8 @@ describe('Translations API', () => {
                     attributes: {
                         labelIds: sampleLabelIds,
                         excludeLabelIds: sampleExcludeLabelIds,
-                    }
-                }
+                    },
+                },
             });
     });
 
@@ -224,10 +223,9 @@ describe('Translations API', () => {
             excludeLabelIds: sampleExcludeLabelIds,
         });
         expect(preTranslation.data.identifier).toBe(preTranslationId);
-        expect(preTranslation.data.attributes.labelIds).toEqual(sampleLabelIds); 
-        expect(preTranslation.data.attributes.excludeLabelIds).toEqual(sampleExcludeLabelIds); 
+        expect(preTranslation.data.attributes.labelIds).toEqual(sampleLabelIds);
+        expect(preTranslation.data.attributes.excludeLabelIds).toEqual(sampleExcludeLabelIds);
     });
-    
 
     it('Pre-translation status', async () => {
         const preTranslation = await api.preTranslationStatus(projectId, preTranslationId);

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -18,6 +18,9 @@ describe('Translations API', () => {
     const directoryId = 61;
     const progress = 50;
     const languageId = 'uk';
+    const sampleLabelIds = [101, 102];
+    const sampleExcludeLabelIds = [103, 104];
+
 
     const limit = 25;
 
@@ -175,6 +178,29 @@ describe('Translations API', () => {
                 data: {
                     url: url,
                 },
+            })
+            .post(
+                `/projects/${projectId}/pre-translations`,
+                {
+                    languageIds: [],
+                    fileIds: [],
+                    labelIds: sampleLabelIds,
+                    excludeLabelIds: sampleExcludeLabelIds,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: preTranslationId,
+                    attributes: {
+                        labelIds: sampleLabelIds,
+                        excludeLabelIds: sampleExcludeLabelIds,
+                    }
+                }
             });
     });
 
@@ -189,6 +215,19 @@ describe('Translations API', () => {
         });
         expect(preTranslation.data.identifier).toBe(preTranslationId);
     });
+
+    it('Apply Pre-Translation with Label Filters', async () => {
+        const preTranslation = await api.applyPreTranslation(projectId, {
+            fileIds: [],
+            languageIds: [],
+            labelIds: sampleLabelIds,
+            excludeLabelIds: sampleExcludeLabelIds,
+        });
+        expect(preTranslation.data.identifier).toBe(preTranslationId);
+        expect(preTranslation.data.attributes.labelIds).toEqual(sampleLabelIds); 
+        expect(preTranslation.data.attributes.excludeLabelIds).toEqual(sampleExcludeLabelIds); 
+    });
+    
 
     it('Pre-translation status', async () => {
         const preTranslation = await api.preTranslationStatus(projectId, preTranslationId);


### PR DESCRIPTION
The new labelIds and excludeLabelIds parameters have been added to the "Apply Pre-Translation" method in this API client.

- Updated PreTranslateRequest interface
- Updated PreTranslationStatusAttributes interface
- Created new test case for labelIds & excludedLabelIds

API Reference:

[Apply Pre-Translation](https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.pre-translations.post)
[Pre-Translation Status](https://developer.crowdin.com/enterprise/api/v2/#tag/Translations/paths/~1projects~1%7BprojectId%7D~1pre-translations~1%7BpreTranslationId%7D/get) (The attributes field now contains them as well)

Issue: #302 