### PR TITLE
feat: Add isPublic property to ReportSettings

### DIFF
--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -328,6 +328,7 @@ export namespace ReportsModel {
         currency: Currency;
         unit: Unit;
         config: ReportSettinsConfig;
+        isPublic: boolean;
         createdAt: string;
         updatedAt: string;
     }

--- a/tests/reports/api.test.ts
+++ b/tests/reports/api.test.ts
@@ -31,6 +31,7 @@ describe('Reports API', () => {
         baseRates: { fullTranslation: 0, proofread: 0 },
         netRateSchemes: [],
     };
+    const isPublic = false;
 
     beforeAll(() => {
         scope = nock(api.url)
@@ -170,6 +171,7 @@ describe('Reports API', () => {
                     currency,
                     unit,
                     config,
+                    isPublic,
                 },
                 {
                     reqheaders: {
@@ -291,6 +293,7 @@ describe('Reports API', () => {
             currency,
             name: reportName,
             unit,
+            isPublic,
         });
         expect(template.data.id).toBe(reportSettingsTemplateId);
     });


### PR DESCRIPTION
Fixes #310 

- Added the `isPublic` property to the ReportSettings Interface
- Updated the Reports API test to include the `isPublic` property in the ReportSettings interface

Completed Pull Request Checklist

- [x] Read the Contributing guidelines.
- [x] Read Code of Conduct.
- [x] Ensure that your code adheres to standard conventions, as used in the rest of the project.
- [x] Ensure that there are unit tests for your code.
- [x]  Run unit tests.
  - [x] Get a failing test after updating the ReportSettings interface
  - [x] Get a passing test after updating the ReportSettings test
- [x] Ensure that docs are correctly generated.


<details>
  <summary><strong>Click here</strong> to see my <strong>failing</strong> test screenshot</summary>
<br>
  <p>Here is a screenshot of my failed test after adding the <i>isPublic</i> property to the <strong>ReportSettings</strong> interface</p>
 <img src="https://github.com/crowdin/crowdin-api-client-js/assets/21162229/5ae332d8-8c38-4166-9830-8a5909e6bb77" alt="Screenshot of a terminal showing 29 passing tests and 1 failed test after adding the isPublic property to the ReportSettings interface. The failed test is unable to determine what isPublic is"/>
</details>

<details>
  <summary><strong>Click here</strong> to see my <strong>passing</strong> tests screenshot</summary>
<br>
  <p>Here is a screenshot of my passing test after adding the <i>isPublic</i> property to the <strong>ReportSettings</strong> test</p>
 <img src="https://github.com/crowdin/crowdin-api-client-js/assets/21162229/48fbdd70-aa2a-4320-8b69-36baa61c35da" alt="Screenshot of a terminal showing all 30 tests passing after running npm run test" />
</details>

<details>
  <summary><strong>Click here</strong> to see <i>isPublic</i> property in the <strong>docs</strong> after full implementation</summary>
<br>
  <p>Here is a screenshot of my local docs with the <i>isPublic</i> property visible in the <strong>ReportSettings</strong> section</p>
 <img src="https://github.com/crowdin/crowdin-api-client-js/assets/21162229/65ed3014-2fb2-4629-ae3a-8f621fa72a5a" alt="Screenshot of API documentation showing the isPublic property is visible in the ReportSettings section" />
</details>