### PR TITLE
fix: Readme.md image not loading issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://support.crowdin.com/assets/logos/symbol/png/crowdin-symbol-cWhite.png">
     <source media="(prefers-color-scheme: light)" srcset="https://support.crowdin.com/assets/logos/symbol/png/crowdin-symbol-cDark.png">
-    <img width="150" height="150" src="[https://support.crowdin.com/assets/logos/symbol/png/crowdin-symbol-cDark.png">
+    <img width="150" height="150" src="https://support.crowdin.com/assets/logos/symbol/png/crowdin-symbol-cDark.png">
   </picture>
 </p>
 


### PR DESCRIPTION
Readme.md Crowdin logo image not loading on coming back after viewing any file. Similar issue in another repo https://github.com/crowdin/crowdin-api-client-php/issues/164

![Screenshot (4)](https://github.com/crowdin/crowdin-api-client-js/assets/103352578/fa1396f7-5d56-45e5-8a27-a04dd347bd30)
