### PR TITLE
fix: add missing field "path" to Directory type

### DIFF
--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -507,6 +507,7 @@ export namespace SourceFilesModel {
         name: string;
         title: string;
         exportPattern: string;
+        path: string;
         priority: Priority;
         createdAt: string;
         updatedAt: string;


### PR DESCRIPTION
The `Directory` interface is missing the `path` property.

<img width="1507" alt="Screenshot 2023-10-30 at 1 43 09 PM" src="https://github.com/crowdin/crowdin-api-client-js/assets/130190082/c75e42c0-afc7-42f3-8a06-c42c925cb311">
