### PR TITLE
fix: print full error message for stringBatchOperations errors

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -156,6 +156,9 @@ export function handleHttpClientError(error: HttpClientError): never {
         const validationCodes: { key: string; codes: string[] }[] = [];
         const validationMessages: string[] = [];
         crowdinResponseErrors.forEach((e: any) => {
+            if (typeof e.index === 'number' && Array.isArray(e.errors)) {
+                throw new CrowdinValidationError(JSON.stringify(crowdinResponseErrors, null, 2), []);
+            }
             if (e.error?.key && Array.isArray(e.error?.errors)) {
                 const codes: string[] = [];
                 e.error.errors.forEach((er: any) => {

--- a/tests/core/error-handling.test.ts
+++ b/tests/core/error-handling.test.ts
@@ -18,19 +18,60 @@ const genericCrowdinErrorPayload = {
     ],
 };
 
+const stringBatchOperationsErrorPayload = {
+    errors: [
+        {
+            index: 0,
+            errors: [
+                {
+                    error: {
+                        key: 'ERROR_KEY',
+                        errors: [
+                            {
+                                message: 'test_errors_error_msg',
+                                code: 'isEmpty',
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            index: 1,
+            errors: [
+                {
+                    error: {
+                        key: 'ERROR_KEY',
+                        errors: [
+                            {
+                                message: 'test_errors_error_msg',
+                                code: 'isEmpty',
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+const createAxiosError = (errorPayload: unknown): AxiosError => {
+    /**
+     * Create an axios error matching Crowdin error responses.
+     * @see https://github.com/axios/axios/blob/3772c8fe74112a56e3e9551f894d899bc3a9443a/test/specs/core/AxiosError.spec.js#L7
+     */
+    const request = { path: '/api/foo' };
+    const response = {
+        status: 200,
+        data: errorPayload,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new AxiosError('Boom!', 'ESOMETHING', {} as any, request, response as any);
+};
+
 describe('core http error handling', () => {
     it('should extract Crowdin API messages with axios client', async () => {
-        /**
-         * Create an axios error matching Crowdin error responses.
-         * @see https://github.com/axios/axios/blob/3772c8fe74112a56e3e9551f894d899bc3a9443a/test/specs/core/AxiosError.spec.js#L7
-         */
-        const request = { path: '/api/foo' };
-        const response = {
-            status: 200,
-            data: genericCrowdinErrorPayload,
-        };
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const error = new AxiosError('Boom!', 'ESOMETHING', {} as any, request, response as any);
+        const error = createAxiosError(genericCrowdinErrorPayload);
         try {
             handleHttpClientError(error);
             throw new Error('expected re-throw');
@@ -45,6 +86,13 @@ describe('core http error handling', () => {
                 },
             ]);
         }
+    });
+
+    it('should print full error message for stringBatchOperations axios errors', async () => {
+        const error = createAxiosError(stringBatchOperationsErrorPayload);
+        expect(() => handleHttpClientError(error)).toThrowError(
+            JSON.stringify(stringBatchOperationsErrorPayload.errors, null, 2),
+        );
     });
 
     it('should extract Crowdin API messages with fetch client', async () => {


### PR DESCRIPTION
## Problem
When `sourceStringsApi.stringBatchOperations` is called with payload errors, the error message has no information about the actual errors.

## Solution
Print full error message


**Before:**
<img width="631" alt="Screenshot 2023-11-16 at 2 10 54 PM" src="https://github.com/crowdin/crowdin-api-client-js/assets/130190082/a412ea7c-9d9d-47b9-852e-80c7cf1a0d27">


**After:**
<img width="470" alt="Screenshot 2023-11-16 at 11 08 16 PM" src="https://github.com/crowdin/crowdin-api-client-js/assets/130190082/fe034900-6cca-46f8-a327-58a81afd5468">

Fixes: https://github.com/crowdin/crowdin-api-client-js/issues/318