### PR TITLE
fix: update TaskModel types

### DIFF
--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -272,135 +272,84 @@ export namespace TasksModel {
         isArchived: boolean;
     }
 
-    export interface CreateTaskEnterpriseRequest {
-        type?: Type;
-        workflowStepId?: number;
+    interface CreateTaskBase {
         title: string;
         languageId: string;
         fileIds: number[];
         status?: RequestStatus;
         description?: string;
-        splitFiles?: boolean;
-        skipAssignedStrings?: boolean;
-        assignees?: CreateTaskAssignee[];
-        includePreTranslatedStringsOnly?: boolean;
-        deadline?: string;
         labelIds?: number[];
         excludeLabelIds?: number[];
         dateFrom?: string;
         dateTo?: string;
     }
 
-    export interface CreateTaskRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateTaskEnterpriseRequest extends CreateTaskBase {
+        type?: Type;
+        workflowStepId?: number;
+        splitFiles?: boolean;
+        skipAssignedStrings?: boolean;
+        assignees?: CreateTaskAssignee[];
+        includePreTranslatedStringsOnly?: boolean;
+        deadline?: string;
+    }
+
+    export interface CreateTaskRequest extends CreateTaskBase {
         type: Type;
-        status?: RequestStatus;
-        description?: string;
         splitFiles?: boolean;
         splitContent?: boolean;
         skipAssignedStrings?: boolean;
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
         assignees?: CreateTaskAssignee[];
         deadline?: string;
         startedAt?: string;
-        dateFrom?: string;
-        dateTo?: string;
     }
 
-    export interface CreateLanguageServiceTaskRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateLanguageServiceTaskRequest extends CreateTaskBase {
         type: TypeVendor;
         vendor: string;
-        status?: RequestStatus;
-        description?: string;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         includeUntranslatedStringsOnly?: boolean;
-        dateFrom?: string;
-        dateTo?: string;
     }
 
-    export interface CreateTaskVendorOhtRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateTaskVendorOhtRequest extends CreateTaskBase {
         type: TypeVendor;
         vendor: string;
-        status?: RequestStatus;
-        description?: string;
         expertise?: Expertise;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         includeUntranslatedStringsOnly?: boolean;
-        dateFrom?: string;
-        dateTo?: string;
     }
 
-    export interface CreateTaskVendorGengoRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateTaskVendorGengoRequest extends CreateTaskBase {
         type: TypeVendor.TRANSLATE_BY_VENDOR;
         vendor: 'gengo';
-        status?: RequestStatus;
-        description?: string;
         expertise?: 'standard' | 'pro';
         tone?: Tone;
         purpose?: Purpose;
         customerMessage?: string;
         usePreferred?: boolean;
         editService?: boolean;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
-        dateFrom?: string;
-        dateTo?: string;
     }
 
-    export interface CreateTaskVendorTranslatedRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateTaskVendorTranslatedRequest extends CreateTaskBase {
         type: TypeVendor.TRANSLATE_BY_VENDOR;
         vendor: 'translated';
-        status?: RequestStatus;
-        description?: string;
         expertise?: TranslatedExpertise;
         subject?: Subject;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
-        dateFrom?: string;
-        dateTo?: string;
     }
 
-    export interface CreateTaskVendorManualRequest {
-        title: string;
-        languageId: string;
-        fileIds: number[];
+    export interface CreateTaskVendorManualRequest extends CreateTaskBase {
         type: TypeVendor;
         vendor: string;
-        status?: RequestStatus;
-        description?: string;
         skipAssignedStrings?: boolean;
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
-        labelIds?: number[];
-        excludeLabelIds?: number[];
         assignees?: CreateTaskAssignee[];
         deadline?: string;
         startedAt?: string;
-        dateFrom?: string;
-        dateTo?: string;
     }
 
     export interface CreateTaskAssignee {

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -237,7 +237,7 @@ export namespace TasksModel {
         id: number;
         projectId: number;
         creatorId: number;
-        type: Type;
+        type: Type | TypeVendor;
         vendor: string;
         status: Status;
         title: string;
@@ -278,7 +278,7 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        status?: Status;
+        status?: RequestStatus;
         description?: string;
         splitFiles?: boolean;
         skipAssignedStrings?: boolean;
@@ -286,6 +286,7 @@ export namespace TasksModel {
         includePreTranslatedStringsOnly?: boolean;
         deadline?: string;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         dateFrom?: string;
         dateTo?: string;
     }
@@ -295,13 +296,15 @@ export namespace TasksModel {
         languageId: string;
         fileIds: number[];
         type: Type;
-        status?: Status;
+        status?: RequestStatus;
         description?: string;
         splitFiles?: boolean;
+        splitContent?: boolean;
         skipAssignedStrings?: boolean;
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         assignees?: CreateTaskAssignee[];
         deadline?: string;
         startedAt?: string;
@@ -313,11 +316,12 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        type: Type;
+        type: TypeVendor;
         vendor: string;
-        status?: Status;
+        status?: RequestStatus;
         description?: string;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         includeUntranslatedStringsOnly?: boolean;
@@ -329,12 +333,13 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        type: Type;
+        type: TypeVendor;
         vendor: string;
-        status?: Status;
+        status?: RequestStatus;
         description?: string;
         expertise?: Expertise;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         includeUntranslatedStringsOnly?: boolean;
@@ -346,17 +351,18 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        type: Type;
-        vendor: string;
-        status?: Status;
+        type: TypeVendor.TRANSLATE_BY_VENDOR;
+        vendor: 'gengo';
+        status?: RequestStatus;
         description?: string;
-        expertise?: Expertise;
+        expertise?: 'standard' | 'pro';
         tone?: Tone;
         purpose?: Purpose;
         customerMessage?: string;
         usePreferred?: boolean;
         editService?: boolean;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         dateFrom?: string;
         dateTo?: string;
     }
@@ -365,13 +371,14 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        type: Type;
-        vendor: string;
-        status?: Status;
+        type: TypeVendor.TRANSLATE_BY_VENDOR;
+        vendor: 'translated';
+        status?: RequestStatus;
         description?: string;
-        expertise?: Expertise;
+        expertise?: TranslatedExpertise;
         subject?: Subject;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         dateFrom?: string;
         dateTo?: string;
     }
@@ -380,14 +387,15 @@ export namespace TasksModel {
         title: string;
         languageId: string;
         fileIds: number[];
-        type: Type;
+        type: TypeVendor;
         vendor: string;
-        status?: Status;
+        status?: RequestStatus;
         description?: string;
         skipAssignedStrings?: boolean;
         skipUntranslatedStrings?: boolean;
         includePreTranslatedStringsOnly?: boolean;
         labelIds?: number[];
+        excludeLabelIds?: number[];
         assignees?: CreateTaskAssignee[];
         deadline?: string;
         startedAt?: string;
@@ -402,10 +410,16 @@ export namespace TasksModel {
 
     export type Status = 'todo' | 'in_progress' | 'done' | 'closed';
 
+    export type RequestStatus = Extract<Status, 'todo' | 'in_progress'>;
+
     export enum Type {
         TRANSLATE = 0,
         PROOFREAD = 1,
+    }
+
+    export enum TypeVendor {
         TRANSLATE_BY_VENDOR = 2,
+        PROOFREAD_BY_VENDOR = 3,
     }
 
     export interface Assignee {
@@ -449,11 +463,18 @@ export namespace TasksModel {
         | 'training-employee-handbooks'
         | 'forex-crypto';
 
+    export enum TranslatedExpertise {
+        ECONOMY = 'P',
+        PROFESSIONAL = 'T',
+        PREMIUM = 'R',
+    }
+
     export type Tone = '' | 'Informal' | 'Friendly' | 'Business' | 'Formal' | 'other';
 
     export type Purpose =
         | 'standard'
         | 'Personal use'
+        | 'Business'
         | 'Online content'
         | 'App/Web localization'
         | 'Media content'


### PR DESCRIPTION
## Problem
The `TasksModel` types don't match the api requirements for the Add Task endpoint

## Fixes
- create `VendorType` (2, 3) and ensure the `type` param matches the requirements for each `CreateTask` type
- create `RequestStatus` to disallow `done` and `closed` statuses for new tasks
- add missing param `excludeLabelIds`
- add missing param `splitContent` to `CreateTaskRequest`
- fix `vendor` and `expertise ` types for `CreateTaskVendorGengoRequest` and `CreateTaskVendorTranslatedRequest`
- add missing union value `"Business"` to `Purpose` type
- create `CreateTaskBase` to hold common params for all task types

```ts
interface CreateTaskBase {
    title: string;
    languageId: string;
    fileIds: number[];
    status?: RequestStatus;
    description?: string;
    labelIds?: number[];
    excludeLabelIds?: number[];
    dateFrom?: string;
    dateTo?: string;
}
```


Ref: https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.post