### PR TITLE
fix: update error message for task creation errors

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -164,7 +164,7 @@ export function handleHttpClientError(error: HttpClientError): never {
         const validationCodes: { key: string; codes: string[] }[] = [];
         const validationMessages: string[] = [];
         crowdinResponseErrors.forEach((e: any) => {
-            if (typeof e.index === 'number' && Array.isArray(e.errors)) {
+            if (typeof e.index === 'number' || typeof e.error?.key === 'number') {
                 throw new CrowdinValidationError(JSON.stringify(crowdinResponseErrors, null, 2), []);
             }
             if (e.error?.key && Array.isArray(e.error?.errors)) {

--- a/tests/core/error-handling.test.ts
+++ b/tests/core/error-handling.test.ts
@@ -80,6 +80,10 @@ const taskCreationErrorPayload = {
     ],
 };
 
+const unrecognizedErrorPayload = {
+    errors: [{ foo: 'bar' }],
+};
+
 const createAxiosError = (errorPayload: unknown): AxiosError => {
     /**
      * Create an axios error matching Crowdin error responses.
@@ -130,6 +134,11 @@ describe('core http error handling', () => {
         expect(() => handleHttpClientError(error)).toThrowError(
             JSON.stringify(taskCreationErrorPayload.errors, null, 2),
         );
+    });
+
+    it('should return default message for unrecognized axios errors', async () => {
+        const error = createAxiosError(unrecognizedErrorPayload);
+        expect(() => handleHttpClientError(error)).toThrowError('Validation error');
     });
 
     it('should extract Crowdin API messages with fetch client', async () => {

--- a/tests/core/error-handling.test.ts
+++ b/tests/core/error-handling.test.ts
@@ -62,6 +62,24 @@ const stringBatchOperationsErrorPayload = {
     ],
 };
 
+const taskCreationErrorPayload = {
+    errors: [
+        {
+            error: {
+                key: 0,
+                errors: [
+                    {
+                        code: 'languageId',
+                        message: {
+                            languageNotSupported: 'This language pair is not supported by vendor',
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+};
+
 const createAxiosError = (errorPayload: unknown): AxiosError => {
     /**
      * Create an axios error matching Crowdin error responses.
@@ -104,6 +122,13 @@ describe('core http error handling', () => {
         const error = createAxiosError(stringBatchOperationsErrorPayload);
         expect(() => handleHttpClientError(error)).toThrowError(
             JSON.stringify(stringBatchOperationsErrorPayload.errors, null, 2),
+        );
+    });
+
+    it('should print full error message for taskCreation axios errors', async () => {
+        const error = createAxiosError(taskCreationErrorPayload);
+        expect(() => handleHttpClientError(error)).toThrowError(
+            JSON.stringify(taskCreationErrorPayload.errors, null, 2),
         );
     });
 


### PR DESCRIPTION
## Problem
There is no useful information in the error message when task creation fails due to a vendor issue

## Solution
Print full error message


**Before:**
<img width="560" alt="Screenshot 2023-12-05 at 12 42 45 PM" src="https://github.com/crowdin/crowdin-api-client-js/assets/130190082/6ed966bd-7691-4263-bb14-57f1eea79a28">


**After:**
<img width="605" alt="Screenshot 2023-12-05 at 1 12 59 PM" src="https://github.com/crowdin/crowdin-api-client-js/assets/130190082/486e856e-2800-4b72-8a4e-5554beec2147">
