### PR TITLE
chore: Dependabot tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     target-branch: "master"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
     ignore:
       - dependency-name: "*" #All the dependency it gonna ignore for major update
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "typedoc"


### PR DESCRIPTION
Group all the dev-deps and temporarily ignore typedoc (TypeScript version incompatibility)