### PR TITLE
fix(screenshots): add missing stringIds query parameter to listScreenshots

### DIFF
--- a/src/screenshots/index.ts
+++ b/src/screenshots/index.ts
@@ -37,6 +37,7 @@ export class Screenshots extends CrowdinApi {
             options = { limit: options, offset: deprecatedOffset };
         }
         let url = `${this.url}/projects/${projectId}/screenshots`;
+        url = this.addQueryParam(url, 'stringIds', options.stringIds?.join(','));
         url = this.addQueryParam(url, 'stringId', options.stringId);
         url = this.addQueryParam(url, 'labelIds', options.labelIds);
         url = this.addQueryParam(url, 'excludeLabelIds', options.excludeLabelIds);


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes a bug where the `stringIds` parameter was defined in the `ListScreenshotParams` interface but was not being passed to the API request.

## 🔧 Changes Made

- Added missing `stringIds` query parameter handling in `listScreenshots` method
- The parameter was already defined in the interface but not implemented in the URL construction

## 🚨 Issue

The `stringIds` option was available in the TypeScript interface but wasn't being sent to the Crowdin API, causing the filtering to not work as expected.

## 📚 Related Documentation

- Crowdin API documentation: [List Screenshots](https://developer.crowdin.com/api/v2/#operation/api.projects.screenshots.getMany)

## ✅ Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] Verified that stringIds parameter is now properly sent to API

## 🚀 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)