### PR TITLE
feat: add support for pre-translation report endpoint

### DIFF
--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -8,6 +8,7 @@ import {
     ResponseObject,
     Status,
 } from '../core';
+import { ProjectsGroupsModel } from '../projectsGroups';
 
 /**
  * Translators can work with entirely untranslated project or you can pre-translate the files to ease the translations process.
@@ -435,14 +436,14 @@ export namespace TranslationsModel {
 
     export interface PreTranslationReport {
         languages: TargetLanguage[];
-        preTranslateType: string;
+        preTranslateType: Method;
     }
 
     export interface TargetLanguage {
         id: string;
         files: TargetLanguageFile[];
         skipped: SkippedInfo;
-        skippedQaCheckCategories: SkippedQaCheckCategories;
+        skippedQaCheckCategories: ProjectsGroupsModel.CheckCategories;
     }
 
     export interface TargetLanguageFile {
@@ -456,10 +457,6 @@ export namespace TranslationsModel {
     }
 
     export interface SkippedInfo {
-        [key: string]: any;
-    }
-
-    export interface SkippedQaCheckCategories {
         [key: string]: any;
     }
 }

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -72,6 +72,19 @@ export class Translations extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param preTranslationId pre translation identifier
+     * @see https://developer.crowdin.com/api/v2/#operation/api.projects.pre-translations.report.getReport
+     */
+    getPreTranslationReport(
+        projectId: number,
+        preTranslationId: string,
+    ): Promise<ResponseObject<TranslationsModel.PreTranslationReport>> {
+        const url = `${this.url}/projects/${projectId}/pre-translations/${preTranslationId}/report`;
+        return this.get(url, this.defaultConfig());
+    }
+
+    /**
+     * @param projectId project identifier
      * @param directoryId directory identifier
      * @param request request body
      * @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.directories.post
@@ -418,5 +431,35 @@ export namespace TranslationsModel {
 
     export interface ListProjectBuildsOptions extends PaginationOptions {
         branchId?: number;
+    }
+
+    export interface PreTranslationReport {
+        languages: TargetLanguage[];
+        preTranslateType: string;
+    }
+
+    export interface TargetLanguage {
+        id: string;
+        files: TargetLanguageFile[];
+        skipped: SkippedInfo;
+        skippedQaCheckCategories: SkippedQaCheckCategories;
+    }
+
+    export interface TargetLanguageFile {
+        id: string;
+        statistics: TargetLanguageFileStatistics;
+    }
+
+    export interface TargetLanguageFileStatistics {
+        phrases: number;
+        words: number;
+    }
+
+    export interface SkippedInfo {
+        [key: string]: any;
+    }
+
+    export interface SkippedQaCheckCategories {
+        [key: string]: any;
     }
 }

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -92,6 +92,32 @@ describe('Translations API', () => {
                     identifier: preTranslationId,
                 },
             })
+            .get(`/projects/${projectId}/pre-translations/${preTranslationId}/report`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .reply(200, {
+                data: {
+                    languages: [
+                        {
+                            id: languageId,
+                            files: [
+                                {
+                                    id: fileId.toString(),
+                                    statistics: {
+                                        phrases: 10,
+                                        words: 25,
+                                    },
+                                },
+                            ],
+                            skipped: {},
+                            skippedQaCheckCategories: {},
+                        },
+                    ],
+                    preTranslateType: 'ai',
+                },
+            })
             .post(
                 `/projects/${projectId}/translations/builds/directories/${directoryId}`,
                 {
@@ -303,6 +329,17 @@ describe('Translations API', () => {
             },
         ]);
         expect(preTranslation.data.identifier).toBe(preTranslationId);
+    });
+
+    it('Get Pre-translation Report', async () => {
+        const report = await api.getPreTranslationReport(projectId, preTranslationId);
+        expect(report.data.languages.length).toBe(1);
+        expect(report.data.languages[0].id).toBe(languageId);
+        expect(report.data.languages[0].files.length).toBe(1);
+        expect(report.data.languages[0].files[0].id).toBe(fileId.toString());
+        expect(report.data.languages[0].files[0].statistics.phrases).toBe(10);
+        expect(report.data.languages[0].files[0].statistics.words).toBe(25);
+        expect(report.data.preTranslateType).toBe('ai');
     });
 
     it('Build Project Direcotry Translation', async () => {


### PR DESCRIPTION
- Add getPreTranslationReport method to Translations class
- Add TypeScript interfaces for PreTranslationReport data models
- Add comprehensive test coverage for the new endpoint
- Resolves #526

The new endpoint allows users to retrieve pre-translation reports containing language-specific file statistics and pre-translation type information for completed pre-translation jobs.

🤖 Generated with [Claude Code](https://claude.ai/code)