### PR TITLE
feat: add support for new report schemas

### DIFF
--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -473,9 +473,19 @@ export namespace ReportsModel {
         schema: any;
     }
 
-    export type GroupReportSchema = GroupTranslationCostsPostEditingSchema | GroupTopMembersSchema;
+    export type GroupReportSchema =
+        | GroupTranslationCostsPostEditingSchema
+        | GroupTopMembersSchema
+        | GroupTaskUsageSchema
+        | GroupQaCheckIssuesSchema
+        | GroupTranslationActivitySchema;
 
-    export type OrganizationReportSchema = GroupTranslationCostsPostEditingSchema | GroupTopMembersSchema;
+    export type OrganizationReportSchema =
+        | GroupTranslationCostsPostEditingSchema
+        | GroupTopMembersSchema
+        | GroupTaskUsageSchema
+        | GroupQaCheckIssuesSchema
+        | GroupTranslationActivitySchema;
 
     export interface GenerateGroupReportRequest {
         name: string;
@@ -567,7 +577,13 @@ export namespace ReportsModel {
         | CostEstimationPostEnding
         | TranslationCostsPostEnding
         | TopMembers
-        | ContributionRawData;
+        | ContributionRawData
+        | SourceContentUpdates
+        | ProjectMembers
+        | EditorIssues
+        | QaCheckIssues
+        | SavingActivity
+        | TranslationActivity;
 
     export type ReportSchema = Pick<GenerateReportRequest, 'schema'>;
 
@@ -599,6 +615,36 @@ export namespace ReportsModel {
     export interface ContributionRawData {
         name: 'contribution-raw-data';
         schema: ContributionRawDataSchema | ContributionRawDataSchemaByTask;
+    }
+
+    export interface SourceContentUpdates {
+        name: 'source-content-updates';
+        schema: SourceContentUpdatesSchema;
+    }
+
+    export interface ProjectMembers {
+        name: 'project-members';
+        schema: MembersSchema;
+    }
+
+    export interface EditorIssues {
+        name: 'editor-issues';
+        schema: EditorIssuesSchema;
+    }
+
+    export interface QaCheckIssues {
+        name: 'qa-check-issues';
+        schema: ProjectQaCheckIssuesSchema;
+    }
+
+    export interface SavingActivity {
+        name: 'saving-activity';
+        schema: SavingActivitySchema;
+    }
+
+    export interface TranslationActivity {
+        name: 'translation-activity';
+        schema: ProjectConsumptionSchema;
     }
 
     export interface ReportStatusAttributes<S> {
@@ -880,4 +926,107 @@ export namespace ReportsModel {
         | 'createdAt'
         | 'updatedAt'
         | 'mark';
+
+    export interface SourceContentUpdatesSchema {
+        unit?: Unit;
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        languageId?: string;
+        userIds?: number[];
+        fileIds?: number[];
+        directoryIds?: number[];
+        branchIds?: number[];
+        labelIds?: number[];
+        labelIncludeType?: LabelIncludeType;
+    }
+
+    export interface MembersSchema {
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+    }
+
+    export interface EditorIssuesSchema {
+        dateFrom?: string;
+        dateTo?: string;
+        format?: Format;
+        languageId?: string;
+        userId?: number;
+    }
+
+    export interface ProjectQaCheckIssuesSchema {
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        languageId?: string;
+    }
+
+    export interface SavingActivitySchema {
+        unit?: Unit;
+        languageId?: string;
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        userIds?: number[];
+        fileIds?: number[];
+        directoryIds?: number[];
+        branchIds?: number[];
+        labelIds?: number[];
+        labelIncludeType?: LabelIncludeType;
+    }
+
+    export interface ProjectConsumptionSchema {
+        unit?: Unit;
+        languageId?: string;
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        userIds?: number[];
+        fileIds?: number[];
+        directoryIds?: number[];
+        branchIds?: number[];
+        labelIds?: number[];
+        labelIncludeType?: LabelIncludeType;
+    }
+
+    export interface GroupTaskUsageSchema {
+        format: Format;
+        type: 'workload' | 'create-vs-resolve' | 'performance' | 'time' | 'cost';
+        projectIds?: number[];
+        assigneeId?: number;
+        creatorId?: number;
+        dateFrom?: string;
+        dateTo?: string;
+        wordsCountFrom?: number;
+        wordsCountTo?: number;
+        excludeApprovalsForEditedTranslations?: boolean;
+        currency?: Currency;
+        baseRates?: BaseRate;
+        individualRates?: IndividualRate[];
+        netRateSchemes?: NetRateSchemas;
+    }
+
+    export interface GroupQaCheckIssuesSchema {
+        projectIds?: number[];
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        languageId?: string;
+    }
+
+    export interface GroupTranslationActivitySchema {
+        projectIds?: number[];
+        unit?: Unit;
+        languageId?: string;
+        format?: Format;
+        dateFrom?: string;
+        dateTo?: string;
+        userIds?: number[];
+        fileIds?: number[];
+        directoryIds?: number[];
+        branchIds?: number[];
+        labelIds?: number[];
+        labelIncludeType?: LabelIncludeType;
+    }
 }

--- a/tests/reports/api.test.ts
+++ b/tests/reports/api.test.ts
@@ -22,6 +22,81 @@ describe('Reports API', () => {
         format: 'json',
         projectIds: [projectId],
     };
+    const sourceContentUpdatesSchema: ReportsModel.SourceContentUpdatesSchema = {
+        unit: 'words',
+        format: 'xlsx',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        languageId: 'en',
+        userIds: [1, 2],
+        fileIds: [10, 20],
+        labelIds: [5],
+        labelIncludeType: 'strings_with_label',
+    };
+    const projectMembersSchema: ReportsModel.MembersSchema = {
+        format: 'csv',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+    };
+    const editorIssuesSchema: ReportsModel.EditorIssuesSchema = {
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        format: 'json',
+        languageId: 'en',
+        userId: 123,
+    };
+    const qaCheckIssuesSchema: ReportsModel.ProjectQaCheckIssuesSchema = {
+        format: 'xlsx',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        languageId: 'en',
+    };
+    const savingActivitySchema: ReportsModel.SavingActivitySchema = {
+        unit: 'words',
+        languageId: 'en',
+        format: 'xlsx',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        userIds: [1, 2],
+        fileIds: [10],
+        labelIds: [5],
+        labelIncludeType: 'strings_with_label',
+    };
+    const translationActivitySchema: ReportsModel.ProjectConsumptionSchema = {
+        unit: 'chars',
+        languageId: 'en',
+        format: 'csv',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        userIds: [1],
+        fileIds: [10, 20],
+        directoryIds: [30],
+        branchIds: [40],
+    };
+    const groupTaskUsageSchema: ReportsModel.GroupTaskUsageSchema = {
+        format: 'xlsx',
+        type: 'workload',
+        projectIds: [projectId],
+        assigneeId: 123,
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+    };
+    const groupQaCheckIssuesSchema: ReportsModel.GroupQaCheckIssuesSchema = {
+        projectIds: [projectId],
+        format: 'csv',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        languageId: 'en',
+    };
+    const groupTranslationActivitySchema: ReportsModel.GroupTranslationActivitySchema = {
+        projectIds: [projectId],
+        unit: 'words',
+        languageId: 'en',
+        format: 'json',
+        dateFrom: '2025-01-01T00:00:00+00:00',
+        dateTo: '2025-01-31T23:59:59+00:00',
+        userIds: [1, 2],
+    };
     const reportSettingsTemplateId = 234;
     const currency: ReportsModel.Currency = 'USD';
     const unit: ReportsModel.Unit = 'words';
@@ -503,7 +578,162 @@ describe('Reports API', () => {
                     Authorization: `Bearer ${api.token}`,
                 },
             })
-            .reply(200);
+            .reply(200)
+            // Project-level new report schema mocks
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'source-content-updates',
+                    schema: sourceContentUpdatesSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'project-members',
+                    schema: projectMembersSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'editor-issues',
+                    schema: editorIssuesSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'qa-check-issues',
+                    schema: qaCheckIssuesSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'saving-activity',
+                    schema: savingActivitySchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/projects/${projectId}/reports`,
+                {
+                    name: 'translation-activity',
+                    schema: translationActivitySchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            // Group-level new report schema mocks
+            .post(
+                `/groups/${groupId}/reports`,
+                {
+                    name: 'group-task-usage',
+                    schema: groupTaskUsageSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/groups/${groupId}/reports`,
+                {
+                    name: 'group-qa-check-issues',
+                    schema: groupQaCheckIssuesSchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            })
+            .post(
+                `/groups/${groupId}/reports`,
+                {
+                    name: 'group-translation-activity',
+                    schema: groupTranslationActivitySchema,
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: reportId,
+                },
+            });
     });
 
     afterAll(() => {
@@ -661,6 +891,78 @@ describe('Reports API', () => {
     it('Download Report', async () => {
         const downloadUrl = await api.downloadReport(projectId, reportId);
         expect(downloadUrl.data.url).toBe(downloadLink);
+    });
+
+    it('Generate Source Content Updates Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'source-content-updates',
+            schema: sourceContentUpdatesSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Project Members Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'project-members',
+            schema: projectMembersSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Editor Issues Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'editor-issues',
+            schema: editorIssuesSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate QA Check Issues Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'qa-check-issues',
+            schema: qaCheckIssuesSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Saving Activity Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'saving-activity',
+            schema: savingActivitySchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Translation Activity Report', async () => {
+        const report = await api.generateReport(projectId, {
+            name: 'translation-activity',
+            schema: translationActivitySchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Group Task Usage Report', async () => {
+        const report = await api.generateGroupReport(groupId, {
+            name: 'group-task-usage',
+            schema: groupTaskUsageSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Group QA Check Issues Report', async () => {
+        const report = await api.generateGroupReport(groupId, {
+            name: 'group-qa-check-issues',
+            schema: groupQaCheckIssuesSchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
+    });
+
+    it('Generate Group Translation Activity Report', async () => {
+        const report = await api.generateGroupReport(groupId, {
+            name: 'group-translation-activity',
+            schema: groupTranslationActivitySchema,
+        });
+        expect(report.data.identifier).toBe(reportId);
     });
 
     it('List Report Settings Templates', async () => {


### PR DESCRIPTION
## Summary
- ✅ Add 6 new project-level report schemas: source-content-updates, project-members, editor-issues, qa-check-issues, saving-activity, translation-activity
- ✅ Add 3 new enterprise group report schemas: group-task-usage, group-qa-check-issues, group-translation-activity
- ✅ Update TypeScript interfaces and union types following existing patterns
- ✅ Add comprehensive test coverage with precise request body validation
- ✅ Fix naming consistency (ProjectMembersSchema -> MembersSchema)

## Test plan
- [x] All existing tests pass (433/433)
- [x] New tests added for each schema type with precise mocks
- [x] TypeScript compilation succeeds
- [x] Linting passes with no new warnings
- [x] Test coverage maintained

## Changes Made
### Core Implementation (`src/reports/index.ts`)
1. **New Project-Level Report Interfaces**: Added 6 interfaces following existing patterns
2. **New Enterprise Group Schemas**: Added 3 group-level report schemas  
3. **Updated Union Types**: Extended `GenerateReportRequest`, `GroupReportSchema`, and `OrganizationReportSchema`
4. **Schema Definitions**: Added complete TypeScript interfaces based on OpenAPI specifications

### Test Implementation (`tests/reports/api.test.ts`)
1. **Precise Test Mocks**: Added specific mocks for each new schema (no generic/persistent mocks)
2. **Comprehensive Coverage**: Test all 9 new report generation endpoints
3. **Request Body Validation**: Tests verify exact request body content and structure

## Breaking Changes
None - this is a purely additive change that maintains backward compatibility.

## Related Issue
Closes #539

🤖 Generated with [Claude Code](https://claude.ai/code)