### PR TITLE
feat: Support for new file reference api

### DIFF
--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -444,7 +444,7 @@ export class SourceFiles extends CrowdinApi {
      * @param options optional pagination parameters for the request
      * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.references.getMany
      */
-    listAccessReferences(
+    listAssetReferences(
         projectId: number,
         fileId: number,
         options?: PaginationOptions,
@@ -487,7 +487,7 @@ export class SourceFiles extends CrowdinApi {
      * @param projectId project identifier
      * @param fileId file identifier
      * @param referenceId reference identifier
-     * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.directories.delete
+     * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.references.delete
      */
     deleteAssetReference(projectId: number, fileId: number, referenceId: number): Promise<void> {
         const url = `${this.url}/projects/${projectId}/files/${fileId}/references/${referenceId}`;

--- a/tests/sourceFiles/api.test.ts
+++ b/tests/sourceFiles/api.test.ts
@@ -715,8 +715,8 @@ describe('Source Files API', () => {
         expect(file.data.url).toBe(filleRawUrl);
     });
 
-    it('List access references', async () => {
-        const references = await api.listAccessReferences(projectId, fileId);
+    it('List asset references', async () => {
+        const references = await api.listAssetReferences(projectId, fileId);
         expect(references.data).toHaveLength(1);
         expect(references.data[0].data.id).toBe(referenceId);
         expect(references.data[0].data.name).toBe(assetName);


### PR DESCRIPTION
Closes #578 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add SourceFiles client support for file asset references (list/get/create/delete) with corresponding models and tests.
> 
> - **API client (`src/sourceFiles/index.ts`)**:
>   - Add `listAssetReferences`, `getAssetReference`, `addAssetReference`, `deleteAssetReference` for `projects/{projectId}/files/{fileId}/references` endpoints.
>   - Define models: `SourceFilesModel.User`, `AssetReference`, `AssetReferenceRequest`.
> - **Tests (`tests/sourceFiles/api.test.ts`)**:
>   - Mock and assert new references endpoints (list/get/post/delete) with nock.
>   - Add related fixtures (`referenceId`, `assetName`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ba061f95e8bc229d9f15ad9fa37ae8446122f4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->