### PR TITLE
feat: update API domain configuration

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -278,11 +278,10 @@ export abstract class CrowdinApi {
         if (config?.url) {
             url = config.url;
         } else {
-            const baseDomain = this.apiDomain || CrowdinApi.CROWDIN_API_DOMAIN;
             if (this.organization) {
-                url = `https://${this.organization}.${baseDomain}/api/graphql`;
+                url = `https://${this.organization}.${this.apiDomain}/api/graphql`;
             } else {
-                url = `https://${baseDomain}/api/graphql`;
+                url = `https://${this.apiDomain}/api/graphql`;
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `apiDomain` in credentials and use it to construct REST/GraphQL endpoints; mark `baseUrl` as deprecated.
> 
> - **Core (`src/core/index.ts`)**:
>   - **Credentials**:
>     - Add `apiDomain` (e.g., `api.crowdin.com`).
>     - Deprecate `baseUrl` (doc-only deprecation note).
>   - **CrowdinApi**:
>     - Introduce `apiDomain` instance field; default to `api.crowdin.com` via `CROWDIN_API_DOMAIN`.
>     - Build REST base URL with `https://<organization?.>${apiDomain}/api/v2`.
>     - Build GraphQL URL with `https://<organization?.>${apiDomain}/api/graphql`.
>     - Replace `CROWDIN_URL_SUFFIX` with `CROWDIN_API_DOMAIN` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2d50aeaf768d590d75caf7e33ea07140d70faaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->