### PR TITLE
feat(tasks): support `listOrganizationTasks` and `listTasksOwnedByUser` endpoints

### DIFF
--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -219,6 +219,56 @@ export class Tasks extends CrowdinApi {
     }
 
     /**
+     * List tasks owned by a specific user
+     * Returns tasks from all projects where the user with the specified ID is the owner/creator
+     * @param userId user identifier
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.users.tasks.getMany
+     */
+    listTasksOwnedByUser(
+        userId: number,
+        options?: TasksModel.ListOrganizationTasksOptions,
+    ): Promise<ResponseList<TasksModel.Task>> {
+        let url = `${this.url}/users/${userId}/tasks`;
+        url = this.addQueryParam(url, 'orderBy', options?.orderBy);
+        url = this.addQueryParam(url, 'status', options?.status);
+        url = this.addQueryParam(url, 'type', options?.type);
+        url = this.addQueryParam(url, 'projectIds', options?.projectIds);
+        url = this.addQueryParam(url, 'groupIds', options?.groupIds);
+        url = this.addQueryParam(url, 'assigneeIds', options?.assigneeIds);
+        url = this.addQueryParam(url, 'creatorIds', options?.creatorIds);
+        url = this.addQueryParam(url, 'targetLanguageIds', options?.targetLanguageIds);
+        url = this.addQueryParam(url, 'sourceLanguageIds', options?.sourceLanguageIds);
+        url = this.addQueryParam(url, 'createdAtFrom', options?.createdAtFrom);
+        url = this.addQueryParam(url, 'createdAtTo', options?.createdAtTo);
+        url = this.addQueryParam(url, 'deadlineFrom', options?.deadlineFrom);
+        url = this.addQueryParam(url, 'deadlineTo', options?.deadlineTo);
+        return this.getList(url, options?.limit, options?.offset);
+    }
+
+    /**
+     * @param options optional parameters for the request
+     * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.tasks.getMany
+     */
+    listOrganizationTasks(options?: TasksModel.ListOrganizationTasksOptions): Promise<ResponseList<TasksModel.Task>> {
+        let url = `${this.url}/tasks`;
+        url = this.addQueryParam(url, 'orderBy', options?.orderBy);
+        url = this.addQueryParam(url, 'status', options?.status);
+        url = this.addQueryParam(url, 'type', options?.type);
+        url = this.addQueryParam(url, 'projectIds', options?.projectIds);
+        url = this.addQueryParam(url, 'groupIds', options?.groupIds);
+        url = this.addQueryParam(url, 'assigneeIds', options?.assigneeIds);
+        url = this.addQueryParam(url, 'creatorIds', options?.creatorIds);
+        url = this.addQueryParam(url, 'targetLanguageIds', options?.targetLanguageIds);
+        url = this.addQueryParam(url, 'sourceLanguageIds', options?.sourceLanguageIds);
+        url = this.addQueryParam(url, 'createdAtFrom', options?.createdAtFrom);
+        url = this.addQueryParam(url, 'createdAtTo', options?.createdAtTo);
+        url = this.addQueryParam(url, 'deadlineFrom', options?.deadlineFrom);
+        url = this.addQueryParam(url, 'deadlineTo', options?.deadlineTo);
+        return this.getList(url, options?.limit, options?.offset);
+    }
+
+    /**
      * @param projectId project identifier
      * @param taskId task identifier
      * @param request request body
@@ -342,6 +392,22 @@ export namespace TasksModel {
         status?: Status;
         isArchived?: BooleanInt;
         orderBy?: string;
+    }
+
+    export interface ListOrganizationTasksOptions extends PaginationOptions {
+        orderBy?: string;
+        status?: string;
+        type?: string;
+        projectIds?: string;
+        groupIds?: string;
+        assigneeIds?: string;
+        creatorIds?: string;
+        targetLanguageIds?: string;
+        sourceLanguageIds?: string;
+        createdAtFrom?: string;
+        createdAtTo?: string;
+        deadlineFrom?: string;
+        deadlineTo?: string;
     }
 
     export interface UserTask extends Task {

--- a/tests/tasks/api.test.ts
+++ b/tests/tasks/api.test.ts
@@ -15,6 +15,7 @@ describe('Tasks API', () => {
     const workflowStepId = 40;
     const link = 'test.com';
     const assigneeId = 1212;
+    const userId = 2;
     const commentId = 55;
     const commentText = 'This is a comment';
 
@@ -215,6 +216,88 @@ describe('Tasks API', () => {
                     limit: limit,
                 },
             })
+            .get(`/users/${userId}/tasks`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: taskId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get(`/users/${userId}/tasks`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query((queryObject) => {
+                return (
+                    queryObject.status === 'done' && queryObject.orderBy === 'createdAt' && queryObject.limit === '10'
+                );
+            })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: taskId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get('/tasks', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: taskId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get('/tasks', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query((queryObject) => {
+                return (
+                    queryObject.status === 'done' && queryObject.orderBy === 'createdAt' && queryObject.limit === '10'
+                );
+            })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: taskId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
             .patch(
                 `/user/tasks/${taskId}?projectId=${projectId}`,
                 [
@@ -399,6 +482,44 @@ describe('Tasks API', () => {
 
     it('List User Tasks', async () => {
         const tasks = await api.listUserTasks();
+        expect(tasks.data.length).toBe(1);
+        expect(tasks.data[0].data.id).toBe(taskId);
+        expect(tasks.pagination.limit).toBe(limit);
+    });
+
+    it('List Tasks Owned By User', async () => {
+        const tasks = await api.listTasksOwnedByUser(userId);
+        expect(tasks.data.length).toBe(1);
+        expect(tasks.data[0].data.id).toBe(taskId);
+        expect(tasks.pagination.limit).toBe(limit);
+    });
+
+    it('List Tasks Owned By User with filters', async () => {
+        const tasks = await api.listTasksOwnedByUser(userId, {
+            status: 'done',
+            orderBy: 'createdAt',
+            limit: 10,
+            offset: 0,
+        });
+        expect(tasks.data.length).toBe(1);
+        expect(tasks.data[0].data.id).toBe(taskId);
+        expect(tasks.pagination.limit).toBe(limit);
+    });
+
+    it('List Organization Tasks', async () => {
+        const tasks = await api.listOrganizationTasks();
+        expect(tasks.data.length).toBe(1);
+        expect(tasks.data[0].data.id).toBe(taskId);
+        expect(tasks.pagination.limit).toBe(limit);
+    });
+
+    it('List Organization Tasks with filters', async () => {
+        const tasks = await api.listOrganizationTasks({
+            status: 'done',
+            orderBy: 'createdAt',
+            limit: 10,
+            offset: 0,
+        });
         expect(tasks.data.length).toBe(1);
         expect(tasks.data[0].data.id).toBe(taskId);
         expect(tasks.pagination.limit).toBe(limit);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `listOrganizationTasks` and `listTasksOwnedByUser` with rich filtering options, plus tests covering both endpoints.
> 
> - **Tasks API**:
>   - Adds `listOrganizationTasks(options)` to list org-wide tasks with filters (`status`, `type`, `projectIds`, `groupIds`, `assigneeIds`, `creatorIds`, `targetLanguageIds`, `sourceLanguageIds`, `createdAtFrom/To`, `deadlineFrom/To`, `orderBy`, pagination).
>   - Adds `listTasksOwnedByUser(userId, options)` to list tasks owned by a user with the same filtering/pagination options.
>   - Introduces `TasksModel.ListOrganizationTasksOptions`.
> - **Tests**:
>   - Adds tests for `listTasksOwnedByUser` (with and without filters).
>   - Adds tests for `listOrganizationTasks` (with and without filters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eafcef37d627dc71bfe3525e53e891ad7518fb89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->