### PR TITLE
feat: new import translations api

### DIFF
--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -507,7 +507,7 @@ export namespace TranslationsModel {
     }
 
     export interface TargetLanguageFile {
-        id: string;
+        id: number;
         statistics: TargetLanguageFileStatistics;
     }
 

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -105,7 +105,7 @@ describe('Translations API', () => {
                             id: languageId,
                             files: [
                                 {
-                                    id: fileId.toString(),
+                                    id: fileId,
                                     statistics: {
                                         phrases: 10,
                                         words: 25,
@@ -305,7 +305,7 @@ describe('Translations API', () => {
                             id: languageId,
                             files: [
                                 {
-                                    id: fileId.toString(),
+                                    id: fileId,
                                     statistics: {
                                         phrases: 10,
                                         words: 25,
@@ -389,7 +389,7 @@ describe('Translations API', () => {
         expect(report.data.languages.length).toBe(1);
         expect(report.data.languages[0].id).toBe(languageId);
         expect(report.data.languages[0].files.length).toBe(1);
-        expect(report.data.languages[0].files[0].id).toBe(fileId.toString());
+        expect(report.data.languages[0].files[0].id).toBe(fileId);
         expect(report.data.languages[0].files[0].statistics.phrases).toBe(10);
         expect(report.data.languages[0].files[0].statistics.words).toBe(25);
         expect(report.data.preTranslateType).toBe('ai');
@@ -484,7 +484,7 @@ describe('Translations API', () => {
         expect(data.languages.length).toBe(1);
         expect(data.languages[0].id).toBe(languageId);
         expect(data.languages[0].files.length).toBe(1);
-        expect(data.languages[0].files[0].id).toBe(fileId.toString());
+        expect(data.languages[0].files[0].id).toBe(fileId);
         expect(data.languages[0].files[0].statistics.phrases).toBe(10);
         expect(data.languages[0].files[0].statistics.words).toBe(25);
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces new translations import flow and aligns types.
> 
> - Adds `importTranslations`, `importTranslationsStatus`, and `importTranslationsReport` endpoints with corresponding models (`ImportTranslationsRequest/StringsRequest`, status attributes, and report types)
> - Marks `uploadTranslation` and `uploadTranslationStrings` as deprecated
> - Changes `PreTranslationReport.TargetLanguageFile.id` from `string` to `number`
> - Updates tests to cover new import endpoints and reflect type changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774260ba7f8724d83904cc75f7acb59247d6185b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->