### PR TITLE
feat(ai): add support for AI Translate Strings endpoint

### DIFF
--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -917,6 +917,20 @@ export class Ai extends CrowdinApi {
 
         return this.patch(url, request, this.defaultConfig());
     }
+
+    /**
+     * @param userId user identifier
+     * @param request request body
+     * @see https://support.crowdin.com/developer/api/v2/#tag/AI/operation/api.users.ai.translate.strings.post
+     */
+    aiUserTranslateStrings(
+        userId: number,
+        request: AiModel.AiTranslateStringsRequest,
+    ): Promise<ResponseObject<Status<AiModel.AiTranslateStringsAttribute>>> {
+        const url = `${this.url}/users/${userId}/ai/translate/strings`;
+
+        return this.post(url, request, this.defaultConfig());
+    }
 }
 
 export namespace AiModel {
@@ -1309,6 +1323,20 @@ export namespace AiModel {
         }[];
     }
     /* ai Settings Section END*/
+
+    /* ai Translate Strings Section START*/
+    export interface AiTranslateStringsRequest {
+        projectId: number;
+        languageId: string;
+        stringIds?: number[];
+    }
+
+    export interface AiTranslateStringsAttribute {
+        projectId: number;
+        languageId: string;
+        stringIds: number[];
+    }
+    /* ai Translate Strings Section END*/
 
     export type Action = 'pre_translate' | 'assist';
     export type ProviderType =

--- a/tests/ai/api.test.ts
+++ b/tests/ai/api.test.ts
@@ -22,6 +22,7 @@ describe('AI API', () => {
     const completionId = 'test-id2';
     const link = 'crowdin.com/test.pdf';
     const projectId = 123;
+    const languageId = 'uk';
     const jobId = 'test-job';
     const eventId = '12312event';
 
@@ -1005,6 +1006,24 @@ describe('AI API', () => {
                 data: {
                     assistActionAiPromptId,
                 },
+            })
+            .post(
+                `/users/${userId}/ai/translate/strings`,
+                {
+                    projectId,
+                    languageId,
+                    stringIds: [1],
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: jobId,
+                },
             });
     });
 
@@ -1460,5 +1479,14 @@ describe('AI API', () => {
             },
         ]);
         expect(settings.data.assistActionAiPromptId).toBe(assistActionAiPromptId);
+    });
+
+    it('AI User Translate Strings', async () => {
+        const res = await api.aiUserTranslateStrings(userId, {
+            projectId,
+            languageId,
+            stringIds: [1],
+        });
+        expect(res.data.identifier).toBe(jobId);
     });
 });


### PR DESCRIPTION
## Description

Adds support for the new **AI Translate Strings** endpoint introduced in the Crowdin API.

### Changes

- Added `aiUserTranslateStrings(userId, request)` method to the `Ai` class — issues `POST /users/{userId}/ai/translate/strings`
- Added `AiModel.AiTranslateStringsRequest` type (request body: `projectId`, `languageId`, optional `stringIds[]`)
- Added `AiModel.AiTranslateStringsAttribute` type (response attribute)
- Added corresponding nock mock and test case in `tests/ai/api.test.ts`

### References

- API docs: https://support.crowdin.com/developer/api/v2/#tag/AI/operation/api.users.ai.translate.strings.post

Resolves https://github.com/crowdin/crowdin-api-client-js/issues/617

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `POST /users/{userId}/ai/translate/strings` client wrapper and corresponding types/tests without changing existing request flows.
> 
> **Overview**
> Adds support for the Crowdin **AI Translate Strings** user endpoint by introducing `aiUserTranslateStrings()` on the `Ai` client, issuing `POST /users/{userId}/ai/translate/strings`.
> 
> Extends `AiModel` with request/response types (`AiTranslateStringsRequest`, `AiTranslateStringsAttribute`) and adds a nock mock + test coverage to validate the new call returns a job `identifier`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d82df9a1dd519195a3ae628f2bc0c036abcdce1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->