### PR TITLE
fix(style-guides): split crowdin and enterprise models

### DIFF
--- a/src/styleGuides/index.ts
+++ b/src/styleGuides/index.ts
@@ -7,7 +7,7 @@ export class StyleGuides extends CrowdinApi {
      */
     listStyleGuides(
         options?: StyleGuidesModel.ListStyleGuidesOptions,
-    ): Promise<ResponseList<StyleGuidesModel.StyleGuide>> {
+    ): Promise<ResponseList<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
         let url = `${this.url}/style-guides`;
         url = this.addQueryParam(url, 'orderBy', options?.orderBy);
         url = this.addQueryParam(url, 'userId', options?.userId);
@@ -19,8 +19,8 @@ export class StyleGuides extends CrowdinApi {
      * @see https://developer.crowdin.com/api/v2/#operation/api.style-guides.post
      */
     createStyleGuide(
-        request: StyleGuidesModel.CreateStyleGuideRequest,
-    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
+        request: StyleGuidesModel.CreateStyleGuideRequest | StyleGuidesModel.CreateStyleGuideEnterpriseRequest,
+    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
         const url = `${this.url}/style-guides`;
         return this.post(url, request, this.defaultConfig());
     }
@@ -29,7 +29,9 @@ export class StyleGuides extends CrowdinApi {
      * @param styleGuideId style guide identifier
      * @see https://developer.crowdin.com/api/v2/#operation/api.style-guides.get
      */
-    getStyleGuide(styleGuideId: number): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
+    getStyleGuide(
+        styleGuideId: number,
+    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
         const url = `${this.url}/style-guides/${styleGuideId}`;
         return this.get(url, this.defaultConfig());
     }
@@ -51,7 +53,7 @@ export class StyleGuides extends CrowdinApi {
     editStyleGuide(
         styleGuideId: number,
         request: PatchRequest[],
-    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
+    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
         const url = `${this.url}/style-guides/${styleGuideId}`;
         return this.patch(url, request, this.defaultConfig());
     }
@@ -72,6 +74,10 @@ export namespace StyleGuidesModel {
         updatedAt: string;
     }
 
+    export interface StyleGuideEnterprise extends StyleGuide {
+        groupId: number;
+    }
+
     export interface CreateStyleGuideRequest {
         name: string;
         storageId: number | null;
@@ -79,6 +85,10 @@ export namespace StyleGuidesModel {
         languageIds?: string[];
         projectIds?: number[];
         isShared?: boolean;
+    }
+
+    export interface CreateStyleGuideEnterpriseRequest extends CreateStyleGuideRequest {
+        groupId?: number | null;
     }
 
     export interface ListStyleGuidesOptions extends PaginationOptions {

--- a/tests/styleGuides/api.test.ts
+++ b/tests/styleGuides/api.test.ts
@@ -9,6 +9,7 @@ describe('Style Guides API', () => {
     };
     const api: StyleGuides = new StyleGuides(credentials);
     const styleGuideId = 2;
+    const groupId = 5;
     const storageId = 1;
     const name = "Be My Eyes iOS's Style Guide";
 
@@ -26,6 +27,7 @@ describe('Style Guides API', () => {
                     {
                         data: {
                             id: styleGuideId,
+                            groupId: groupId,
                         },
                     },
                 ],
@@ -46,9 +48,10 @@ describe('Style Guides API', () => {
                     },
                 },
             )
-            .reply(200, {
+            .reply(201, {
                 data: {
                     id: styleGuideId,
+                    groupId: groupId,
                 },
             })
             .get(`/style-guides/${styleGuideId}`, undefined, {
@@ -59,6 +62,7 @@ describe('Style Guides API', () => {
             .reply(200, {
                 data: {
                     id: styleGuideId,
+                    groupId: groupId,
                 },
             })
             .delete(`/style-guides/${styleGuideId}`, undefined, {
@@ -85,6 +89,7 @@ describe('Style Guides API', () => {
             .reply(200, {
                 data: {
                     id: styleGuideId,
+                    groupId: groupId,
                 },
             });
     });
@@ -103,11 +108,13 @@ describe('Style Guides API', () => {
     it('Create style guide', async () => {
         const styleGuide = await api.createStyleGuide({ name, storageId });
         expect(styleGuide.data.id).toBe(styleGuideId);
+        expect(styleGuide.data).toHaveProperty('groupId', groupId);
     });
 
     it('Get style guide', async () => {
         const styleGuide = await api.getStyleGuide(styleGuideId);
         expect(styleGuide.data.id).toBe(styleGuideId);
+        expect(styleGuide.data).toHaveProperty('groupId', groupId);
     });
 
     it('Delete style guide', async () => {
@@ -123,5 +130,6 @@ describe('Style Guides API', () => {
             },
         ]);
         expect(styleGuide.data.id).toBe(styleGuideId);
+        expect(styleGuide.data).toHaveProperty('groupId', groupId);
     });
 });


### PR DESCRIPTION
Separate Style Guides request and response typings for Crowdin and Enterprise while keeping shared API methods backward compatible.
