### PR TITLE
fix(style-guides): simplify dual-platform models with optional groupId

### DIFF
--- a/src/styleGuides/index.ts
+++ b/src/styleGuides/index.ts
@@ -7,7 +7,7 @@ export class StyleGuides extends CrowdinApi {
      */
     listStyleGuides(
         options?: StyleGuidesModel.ListStyleGuidesOptions,
-    ): Promise<ResponseList<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
+    ): Promise<ResponseList<StyleGuidesModel.StyleGuide>> {
         let url = `${this.url}/style-guides`;
         url = this.addQueryParam(url, 'orderBy', options?.orderBy);
         url = this.addQueryParam(url, 'userId', options?.userId);
@@ -19,8 +19,8 @@ export class StyleGuides extends CrowdinApi {
      * @see https://developer.crowdin.com/api/v2/#operation/api.style-guides.post
      */
     createStyleGuide(
-        request: StyleGuidesModel.CreateStyleGuideRequest | StyleGuidesModel.CreateStyleGuideEnterpriseRequest,
-    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
+        request: StyleGuidesModel.CreateStyleGuideRequest,
+    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
         const url = `${this.url}/style-guides`;
         return this.post(url, request, this.defaultConfig());
     }
@@ -29,9 +29,7 @@ export class StyleGuides extends CrowdinApi {
      * @param styleGuideId style guide identifier
      * @see https://developer.crowdin.com/api/v2/#operation/api.style-guides.get
      */
-    getStyleGuide(
-        styleGuideId: number,
-    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
+    getStyleGuide(styleGuideId: number): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
         const url = `${this.url}/style-guides/${styleGuideId}`;
         return this.get(url, this.defaultConfig());
     }
@@ -53,7 +51,7 @@ export class StyleGuides extends CrowdinApi {
     editStyleGuide(
         styleGuideId: number,
         request: PatchRequest[],
-    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide | StyleGuidesModel.StyleGuideEnterprise>> {
+    ): Promise<ResponseObject<StyleGuidesModel.StyleGuide>> {
         const url = `${this.url}/style-guides/${styleGuideId}`;
         return this.patch(url, request, this.defaultConfig());
     }
@@ -72,10 +70,8 @@ export namespace StyleGuidesModel {
         downloadLink: string;
         createdAt: string;
         updatedAt: string;
-    }
-
-    export interface StyleGuideEnterprise extends StyleGuide {
-        groupId: number;
+        /** Enterprise only */
+        groupId?: number;
     }
 
     export interface CreateStyleGuideRequest {
@@ -85,9 +81,7 @@ export namespace StyleGuidesModel {
         languageIds?: string[];
         projectIds?: number[];
         isShared?: boolean;
-    }
-
-    export interface CreateStyleGuideEnterpriseRequest extends CreateStyleGuideRequest {
+        /** Enterprise only */
         groupId?: number | null;
     }
 

--- a/tests/styleGuides/api.test.ts
+++ b/tests/styleGuides/api.test.ts
@@ -108,13 +108,13 @@ describe('Style Guides API', () => {
     it('Create style guide', async () => {
         const styleGuide = await api.createStyleGuide({ name, storageId });
         expect(styleGuide.data.id).toBe(styleGuideId);
-        expect(styleGuide.data).toHaveProperty('groupId', groupId);
+        expect(styleGuide.data.groupId).toBe(groupId);
     });
 
     it('Get style guide', async () => {
         const styleGuide = await api.getStyleGuide(styleGuideId);
         expect(styleGuide.data.id).toBe(styleGuideId);
-        expect(styleGuide.data).toHaveProperty('groupId', groupId);
+        expect(styleGuide.data.groupId).toBe(groupId);
     });
 
     it('Delete style guide', async () => {
@@ -130,6 +130,6 @@ describe('Style Guides API', () => {
             },
         ]);
         expect(styleGuide.data.id).toBe(styleGuideId);
-        expect(styleGuide.data).toHaveProperty('groupId', groupId);
+        expect(styleGuide.data.groupId).toBe(groupId);
     });
 });


### PR DESCRIPTION
# fix(style-guides): simplify dual-platform models with optional groupId

## Summary

Simplifies Style Guides API models to use a single interface with optional `groupId` instead of separate Crowdin/Enterprise interfaces. Aligns with the pattern used in `machineTranslation` and other dual-platform modules.

## Changes

- **`StyleGuide`**: Added optional `groupId?: number` (Enterprise only) instead of `StyleGuideEnterprise` interface
- **`CreateStyleGuideRequest`**: Added optional `groupId?: number | null` (Enterprise only) instead of `CreateStyleGuideEnterpriseRequest`
- **Method signatures**: Removed union types (`StyleGuide | StyleGuideEnterprise`), now return `StyleGuide` directly
- **Tests**: Updated assertions to use direct `groupId` access

## Rationale

Style Guides API serves both [Crowdin](https://support.crowdin.com/developer/api/v2/#tag/Style-Guides) and [Crowdin Enterprise](https://support.crowdin.com/developer/enterprise/api/v2/#tag/Style-Guides). The only platform-specific difference is `groupId` (Enterprise). Using optional `groupId` keeps the API surface simpler and consistent.
