### PR TITLE
ci: switch npm publish workflow to staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm publish --dry-run
 
       - name: Publish the package
-        run: npm publish --provenance
+        run: npm stage publish --provenance


### PR DESCRIPTION
Switched the npm release workflow to staged publishing (npm stage publish). This adds an approval gate before a version becomes installable, reducing supply-chain risk while keeping our CI release flow unchanged otherwise.