### PR TITLE
feat(bundles): add export settings to export bundle

### DIFF
--- a/src/bundles/index.ts
+++ b/src/bundles/index.ts
@@ -82,11 +82,16 @@ export class Bundles extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param bundleId bundle identifier
+     * @param request request body
      * @see https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.exports.post
      */
-    exportBundle(projectId: number, bundleId: number): Promise<ResponseObject<Status<BundlesModel.ExportAttributes>>> {
+    exportBundle(
+        projectId: number,
+        bundleId: number,
+        request?: BundlesModel.ExportBundleRequest,
+    ): Promise<ResponseObject<BundlesModel.BundleExportStatus>> {
         const url = `${this.url}/projects/${projectId}/bundles/${bundleId}/exports`;
-        return this.post(url, undefined, this.defaultConfig());
+        return this.post(url, request, this.defaultConfig());
     }
 
     /**
@@ -99,7 +104,7 @@ export class Bundles extends CrowdinApi {
         projectId: number,
         bundleId: number,
         exportId: string,
-    ): Promise<ResponseObject<Status<BundlesModel.ExportAttributes>>> {
+    ): Promise<ResponseObject<BundlesModel.BundleExportStatus>> {
         const url = `${this.url}/projects/${projectId}/bundles/${bundleId}/exports/${exportId}`;
         return this.get(url, this.defaultConfig());
     }
@@ -164,7 +169,31 @@ export namespace BundlesModel {
         excludeLabelIds?: number[];
     }
 
+    export interface ExportBundleRequest {
+        targetLanguageIds?: string[];
+        skipUntranslatedStrings?: boolean;
+        skipUntranslatedFiles?: boolean;
+        // community
+        exportApprovedOnly?: boolean;
+        // enterprise
+        exportWithMinApprovalsCount?: number;
+        exportStringsThatPassedWorkflow?: boolean;
+    }
+
     export interface ExportAttributes {
         bundleId: number;
+        targetLanguageIds: string[];
+        skipUntranslatedStrings: boolean;
+        skipUntranslatedFiles: boolean;
+        // community
+        exportApprovedOnly: boolean;
+        // enterprise
+        exportWithMinApprovalsCount: number;
+        exportStringsThatPassedWorkflow: boolean;
     }
+
+    export type BundleExportStatus = Omit<Status<ExportAttributes>, 'startedAt' | 'finishedAt'> & {
+        startedAt: string | null;
+        finishedAt: string | null;
+    };
 }

--- a/src/bundles/index.ts
+++ b/src/bundles/index.ts
@@ -182,14 +182,14 @@ export namespace BundlesModel {
 
     export interface ExportAttributes {
         bundleId: number;
-        targetLanguageIds: string[];
-        skipUntranslatedStrings: boolean;
-        skipUntranslatedFiles: boolean;
+        targetLanguageIds?: string[];
+        skipUntranslatedStrings?: boolean;
+        skipUntranslatedFiles?: boolean;
         // community
-        exportApprovedOnly: boolean;
+        exportApprovedOnly?: boolean;
         // enterprise
-        exportWithMinApprovalsCount: number;
-        exportStringsThatPassedWorkflow: boolean;
+        exportWithMinApprovalsCount?: number;
+        exportStringsThatPassedWorkflow?: boolean;
     }
 
     export type BundleExportStatus = Omit<Status<ExportAttributes>, 'startedAt' | 'finishedAt'> & {

--- a/src/bundles/index.ts
+++ b/src/bundles/index.ts
@@ -89,7 +89,7 @@ export class Bundles extends CrowdinApi {
         projectId: number,
         bundleId: number,
         request?: BundlesModel.ExportBundleRequest,
-    ): Promise<ResponseObject<BundlesModel.BundleExportStatus>> {
+    ): Promise<ResponseObject<Status<BundlesModel.ExportAttributes>>> {
         const url = `${this.url}/projects/${projectId}/bundles/${bundleId}/exports`;
         return this.post(url, request, this.defaultConfig());
     }
@@ -104,7 +104,7 @@ export class Bundles extends CrowdinApi {
         projectId: number,
         bundleId: number,
         exportId: string,
-    ): Promise<ResponseObject<BundlesModel.BundleExportStatus>> {
+    ): Promise<ResponseObject<Status<BundlesModel.ExportAttributes>>> {
         const url = `${this.url}/projects/${projectId}/bundles/${bundleId}/exports/${exportId}`;
         return this.get(url, this.defaultConfig());
     }
@@ -191,9 +191,4 @@ export namespace BundlesModel {
         exportWithMinApprovalsCount?: number;
         exportStringsThatPassedWorkflow?: boolean;
     }
-
-    export type BundleExportStatus = Omit<Status<ExportAttributes>, 'startedAt' | 'finishedAt'> & {
-        startedAt: string | null;
-        finishedAt: string | null;
-    };
 }

--- a/tests/bundles/api.test.ts
+++ b/tests/bundles/api.test.ts
@@ -105,14 +105,35 @@ describe('Bundles API', () => {
                     url: exportUrl,
                 },
             })
-            .post(`/projects/${projectId}/bundles/${bundleId}/exports`, undefined, {
-                reqheaders: {
-                    Authorization: `Bearer ${api.token}`,
+            .post(
+                `/projects/${projectId}/bundles/${bundleId}/exports`,
+                {
+                    targetLanguageIds: ['uk'],
+                    skipUntranslatedStrings: false,
+                    exportApprovedOnly: true,
                 },
-            })
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
             .reply(200, {
                 data: {
                     identifier: exportId,
+                    status: 'finished',
+                    progress: 100,
+                    attributes: {
+                        bundleId,
+                        targetLanguageIds: ['uk'],
+                        skipUntranslatedStrings: false,
+                        skipUntranslatedFiles: false,
+                        exportApprovedOnly: true,
+                    },
+                    createdAt: '2019-09-23T11:26:54+00:00',
+                    updatedAt: '2019-09-23T11:26:54+00:00',
+                    startedAt: null,
+                    finishedAt: '2019-09-23T11:26:54+00:00',
                 },
             })
             .get(`/projects/${projectId}/bundles/${bundleId}/exports/${exportId}`, undefined, {
@@ -123,6 +144,19 @@ describe('Bundles API', () => {
             .reply(200, {
                 data: {
                     identifier: exportId,
+                    status: 'finished',
+                    progress: 100,
+                    attributes: {
+                        bundleId,
+                        targetLanguageIds: ['uk'],
+                        skipUntranslatedStrings: false,
+                        skipUntranslatedFiles: false,
+                        exportApprovedOnly: true,
+                    },
+                    createdAt: '2019-09-23T11:26:54+00:00',
+                    updatedAt: '2019-09-23T11:26:54+00:00',
+                    startedAt: null,
+                    finishedAt: '2019-09-23T11:26:54+00:00',
                 },
             })
             .get(`/projects/${projectId}/bundles/${bundleId}/files`, undefined, {
@@ -210,13 +244,21 @@ describe('Bundles API', () => {
     });
 
     it('Export bundle', async () => {
-        const resp = await api.exportBundle(projectId, bundleId);
+        const resp = await api.exportBundle(projectId, bundleId, {
+            targetLanguageIds: ['uk'],
+            skipUntranslatedStrings: false,
+            exportApprovedOnly: true,
+        });
         expect(resp.data.identifier).toBe(exportId);
+        expect(resp.data.attributes.exportApprovedOnly).toBe(true);
+        expect(resp.data.startedAt).toBeNull();
     });
 
     it('Check bundle export status', async () => {
         const resp = await api.checkBundleExportStatus(projectId, bundleId, exportId);
         expect(resp.data.identifier).toBe(exportId);
+        expect(resp.data.attributes.targetLanguageIds).toEqual(['uk']);
+        expect(resp.data.finishedAt).toBe('2019-09-23T11:26:54+00:00');
     });
 
     it('Bundle list files', async () => {


### PR DESCRIPTION
## Changes

- Added ExportBundleRequest interface
- Added request body support for Export Bundle endpoint
- Added export settings to bundle export response attributes
- Made startedAt and finishedAt nullable
- Updated Check Bundle Export Status response types
- Added tests

Fixes #678