### PR TITLE
feat(translations): add new pre-translate parameters

### DIFF
--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -317,36 +317,56 @@ export namespace TranslationsModel {
         languageIds: string[];
         fileIds: number[];
         method?: Method;
+        priority?: Priority;
         engineId?: number;
         aiPromptId?: number;
         autoApproveOption?: AutoApproveOption;
         duplicateTranslations?: boolean;
         skipApprovedTranslations?: boolean;
+        /**
+         * @deprecated Use {@link scope} instead
+         */
         translateUntranslatedOnly?: boolean;
+        scope?: Scope;
+        translationModifiedBefore?: string;
+        replaceTranslationsOption?: ReplaceTranslationsOption;
+        resetApprovalStatus?: boolean;
         translateWithPerfectMatchOnly?: boolean;
         fallbackLanguages?: {
             languageId?: string[];
         };
         labelIds?: number[];
         excludeLabelIds?: number[];
+        sourceLanguageId?: string;
+        customInstruction?: string;
     }
 
     export interface PreTranslateStringsRequest {
         languageIds: string[];
         branchIds?: number[];
         method?: Method;
+        priority?: Priority;
         engineId?: number;
         aiPromptId?: number;
         autoApproveOption?: AutoApproveOption;
         duplicateTranslations?: boolean;
         skipApprovedTranslations?: boolean;
+        /**
+         * @deprecated Use {@link scope} instead
+         */
         translateUntranslatedOnly?: boolean;
+        scope?: Scope;
+        translationModifiedBefore?: string;
+        replaceTranslationsOption?: ReplaceTranslationsOption;
+        resetApprovalStatus?: boolean;
         translateWithPerfectMatchOnly?: boolean;
         fallbackLanguages?: {
             languageId: string[];
         };
         labelIds?: number[];
         excludeLabelIds?: number[];
+        sourceLanguageId?: string;
+        customInstruction?: string;
     }
 
     export interface BuildProjectDirectoryTranslationRequest {
@@ -407,7 +427,16 @@ export namespace TranslationsModel {
 
     export type Method = 'tm' | 'mt' | 'ai';
 
-    export type AutoApproveOption = 'all' | 'exceptAutoSubstituted' | 'perfectMatchOnly' | 'none';
+    export type AutoApproveOption =
+        | 'all'
+        | 'exceptAutoSubstituted'
+        | 'perfectMatchOnly'
+        | 'perfectMatchApprovedOnly'
+        | 'none';
+
+    export type Scope = 'untranslated' | 'translated' | 'all';
+
+    export type ReplaceTranslationsOption = 'none' | 'autoTranslated' | 'all';
 
     export type Priority = 'low' | 'normal' | 'high';
 

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -360,6 +360,32 @@ describe('Translations API', () => {
                     identifier: preTranslationId,
                     attributes: {},
                 },
+            })
+            .post(
+                `/projects/${projectId}/pre-translations`,
+                {
+                    languageIds: [],
+                    fileIds: [],
+                    method: 'ai',
+                    priority: 'high',
+                    scope: 'untranslated',
+                    translationModifiedBefore: '2024-01-01T00:00:00+00:00',
+                    replaceTranslationsOption: 'autoTranslated',
+                    resetApprovalStatus: true,
+                    sourceLanguageId: 'en',
+                    customInstruction: 'Translate formally',
+                },
+                {
+                    reqheaders: {
+                        Authorization: `Bearer ${api.token}`,
+                    },
+                },
+            )
+            .reply(200, {
+                data: {
+                    identifier: preTranslationId,
+                    attributes: {},
+                },
             });
     });
 
@@ -388,6 +414,22 @@ describe('Translations API', () => {
             languageIds: [],
             labelIds: sampleLabelIds,
             excludeLabelIds: sampleExcludeLabelIds,
+        });
+        expect(preTranslation.data.identifier).toBe(preTranslationId);
+    });
+
+    it('Apply Pre-Translation with new options', async () => {
+        const preTranslation = await api.applyPreTranslation(projectId, {
+            fileIds: [],
+            languageIds: [],
+            method: 'ai',
+            priority: 'high',
+            scope: 'untranslated',
+            translationModifiedBefore: '2024-01-01T00:00:00+00:00',
+            replaceTranslationsOption: 'autoTranslated',
+            resetApprovalStatus: true,
+            sourceLanguageId: 'en',
+            customInstruction: 'Translate formally',
         });
         expect(preTranslation.data.identifier).toBe(preTranslationId);
     });


### PR DESCRIPTION
Add the new parameters supported by the pre-translate endpoint: scope, translationModifiedBefore, replaceTranslationsOption, resetApprovalStatus, priority, sourceLanguageId and customInstruction.

Mark translateUntranslatedOnly as deprecated in favor of scope, and add the perfectMatchApprovedOnly value to AutoApproveOption.