### PR TITLE
fix: send force query param on app uninstall

### DIFF
--- a/src/applications/index.ts
+++ b/src/applications/index.ts
@@ -44,9 +44,9 @@ export class Applications extends CrowdinApi {
         applicationId: string,
         force?: boolean,
     ): Promise<ResponseObject<ApplicationsModel.Application>> {
-        const url = `${this.url}/applications/installations/${applicationId}`;
+        let url = `${this.url}/applications/installations/${applicationId}`;
         if (force) {
-            this.addQueryParam(url, 'force', String(force));
+            url = this.addQueryParam(url, 'force', String(force));
         }
         return this.delete(url, this.defaultConfig());
     }

--- a/tests/applications/api.test.ts
+++ b/tests/applications/api.test.ts
@@ -54,6 +54,13 @@ describe('Applications API', () => {
                 },
             })
             .reply(200)
+            .delete(installUrl + `/${applicationId}`, undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ force: 'true' })
+            .reply(200)
             .post(
                 url,
                 {},
@@ -127,6 +134,10 @@ describe('Applications API', () => {
 
     it('Delete Application Installation', async () => {
         await api.deleteApplicationInstallation(applicationId);
+    });
+
+    it('Delete Application Installation with force', async () => {
+        await api.deleteApplicationInstallation(applicationId, true);
     });
 
     it('Add Application Data', async () => {


### PR DESCRIPTION
### Description

`ApplicationsApi.deleteApplicationInstallation(applicationId, force)` builds the URL, calls
`addQueryParam`, and throws the returned string away. `addQueryParam` is pure — it returns a new
string rather than mutating its argument — so the request goes out without `?force=true` and the
flag is silently ignored.

```js
// out/applications/index.js (1.56.3)
deleteApplicationInstallation(applicationId, force) {
    const url = `${this.url}/applications/installations/${applicationId}`;
    if (force) {
        this.addQueryParam(url, 'force', String(force));   // ← return value dropped
    }
    return this.delete(url, this.defaultConfig());
}
```

Every other call site in the library assigns the result back, e.g. in `core`:

```js
let urlWithPagination = this.addQueryParam(url, 'limit', limit);
urlWithPagination = this.addQueryParam(urlWithPagination, 'offset', offset);
```

This is the only discarded `addQueryParam` call in the published output.

### Reproduction

```ts
const client = new Client({ token });
await client.applicationsApi.deleteApplicationInstallation('some_app', true);
// DELETE /applications/installations/some_app
// expected: DELETE /applications/installations/some_app?force=true
```

The call still succeeds and the installation is removed, so the bug is invisible unless the request
is inspected — the caller just never gets force semantics.

### Expected

```js
let url = `${this.url}/applications/installations/${applicationId}`;
if (force) {
    url = this.addQueryParam(url, 'force', String(force));
}
return this.delete(url, this.defaultConfig());
```