### PR TITLE
feat: add org-level search endpoints for branches, directories, files…

### DIFF
--- a/src/sourceFiles/index.ts
+++ b/src/sourceFiles/index.ts
@@ -63,6 +63,18 @@ export class SourceFiles extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.branches.getMany
+     */
+    listBranches(options: SourceFilesModel.ListBranchesOptions): Promise<ResponseList<SourceFilesModel.Branch>> {
+        let url = `${this.url}/branches`;
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'projectIds', options.projectIds?.join(','));
+        url = this.addQueryParam(url, 'userId', options.userId);
+        return this.getList(url, options.limit, options.offset);
+    }
+
+    /**
      * @param projectId project identifier
      * @param options optional parameters for the request
      * @see https://developer.crowdin.com/api/v2/#operation/api.projects.branches.getMany
@@ -218,6 +230,20 @@ export class SourceFiles extends CrowdinApi {
     }
 
     /**
+     * @param options optional parameters for the request
+     * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.directories.getMany
+     */
+    listDirectories(
+        options: SourceFilesModel.ListDirectoriesOptions,
+    ): Promise<ResponseList<SourceFilesModel.Directory>> {
+        let url = `${this.url}/directories`;
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'projectIds', options.projectIds?.join(','));
+        url = this.addQueryParam(url, 'userId', options.userId);
+        return this.getList(url, options.limit, options.offset);
+    }
+
+    /**
      * @param projectId project identifier
      * @param options optional parameters for the request
      * @see https://developer.crowdin.com/api/v2/#operation/api.projects.directories.getMany
@@ -344,6 +370,18 @@ export class SourceFiles extends CrowdinApi {
     ): Promise<ResponseObject<SourceFilesModel.Directory>> {
         const url = `${this.url}/projects/${projectId}/directories/${directoryId}`;
         return this.patch(url, request, this.defaultConfig());
+    }
+
+    /**
+     * @param options optional parameters for the request
+     * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.files.getMany
+     */
+    listFiles(options: SourceFilesModel.ListFilesOptions): Promise<ResponseList<SourceFilesModel.File>> {
+        let url = `${this.url}/files`;
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'projectIds', options.projectIds?.join(','));
+        url = this.addQueryParam(url, 'userId', options.userId);
+        return this.getList(url, options.limit, options.offset);
     }
 
     /**
@@ -1125,5 +1163,23 @@ export namespace SourceFilesModel {
         startedAt: string;
         finishedAt: string;
         error: { message: string } | null;
+    }
+
+    export interface ListBranchesOptions extends PaginationOptions {
+        filter: string;
+        projectIds?: number[];
+        userId?: number;
+    }
+
+    export interface ListDirectoriesOptions extends PaginationOptions {
+        filter: string;
+        projectIds?: number[];
+        userId?: number;
+    }
+
+    export interface ListFilesOptions extends PaginationOptions {
+        filter: string;
+        projectIds?: number[];
+        userId?: number;
     }
 }

--- a/src/sourceStrings/index.ts
+++ b/src/sourceStrings/index.ts
@@ -190,6 +190,20 @@ export class SourceStrings extends CrowdinApi {
         url = this.addQueryParam(url, 'updateOption', query?.updateOption);
         return this.patch(url, request, this.defaultConfig());
     }
+
+    /**
+     * @param options optional parameters for the request
+     * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.strings.getMany
+     */
+    listStrings(options: SourceStringsModel.ListStringsOptions): Promise<ResponseList<SourceStringsModel.String>> {
+        let url = `${this.url}/strings`;
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'projectIds', options.projectIds?.join(','));
+        url = this.addQueryParam(url, 'userId', options.userId);
+        url = this.addQueryParam(url, 'scope', options.scope);
+        url = this.addQueryParam(url, 'denormalizePlaceholders', options.denormalizePlaceholders);
+        return this.getList(url, options.limit, options.offset);
+    }
 }
 
 export namespace SourceStringsModel {
@@ -315,4 +329,12 @@ export namespace SourceStringsModel {
         | 'clear_translations_and_approvals'
         | 'keep_translations'
         | 'keep_translations_and_approvals';
+
+    export interface ListStringsOptions extends PaginationOptions {
+        filter: string;
+        projectIds?: number[];
+        userId?: number;
+        scope?: 'all' | 'text' | 'context' | 'key';
+        denormalizePlaceholders?: BooleanInt;
+    }
 }

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -310,6 +310,22 @@ export class Translations extends CrowdinApi {
         const url = `${this.url}/projects/${projectId}/translations/imports/${importId}/report`;
         return this.get(url, this.defaultConfig());
     }
+
+    /**
+     * @param options optional parameters for the request
+     * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.translations.getMany
+     */
+    listTranslations(
+        options: TranslationsModel.ListTranslationsOptions,
+    ): Promise<ResponseList<TranslationsModel.TranslationSearchResult>> {
+        let url = `${this.url}/translations`;
+        url = this.addQueryParam(url, 'filter', options.filter);
+        url = this.addQueryParam(url, 'projectIds', options.projectIds?.join(','));
+        url = this.addQueryParam(url, 'userId', options.userId);
+        url = this.addQueryParam(url, 'languageIds', options.languageIds?.join(','));
+        url = this.addQueryParam(url, 'denormalizePlaceholders', options.denormalizePlaceholders);
+        return this.getList(url, options.limit, options.offset);
+    }
 }
 
 export namespace TranslationsModel {
@@ -664,4 +680,25 @@ export namespace TranslationsModel {
     }
 
     /* Import Translations END */
+
+    export interface ListTranslationsOptions extends PaginationOptions {
+        filter: string;
+        projectIds?: number[];
+        userId?: number;
+        languageIds?: string[];
+        denormalizePlaceholders?: 0 | 1;
+    }
+
+    export interface TranslationSearchResult {
+        id: number;
+        text: string;
+        projectId: number;
+        stringId: number;
+        languageId: string;
+        provider: string;
+        isPreTranslated: boolean;
+        matchRate: number;
+        matchType: string;
+        createdAt: string;
+    }
 }

--- a/tests/sourceFiles/api.test.ts
+++ b/tests/sourceFiles/api.test.ts
@@ -37,6 +37,7 @@ describe('Source Files API', () => {
     const referenceId = 543;
     const assetName = 'asset.png';
     const jobId = 'test-job-id';
+    const filter = 'hello';
 
     beforeAll(() => {
         scope = nock(api.url)
@@ -648,6 +649,63 @@ describe('Source Files API', () => {
                     finishedAt: '2023-01-01T00:00:00+00:00',
                     error: null,
                 },
+            })
+            .get('/branches', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ filter })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: branchId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get('/directories', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ filter })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: directoryId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
+            })
+            .get('/files', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ filter })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: fileId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
             });
     });
 
@@ -919,5 +977,26 @@ describe('Source Files API', () => {
         const job = await api.checkDeleteFileJobStatus(projectId, fileId, jobId);
         expect(job.data.identifier).toBe(jobId);
         expect(job.data.status).toBe('finished');
+    });
+
+    it('List branches', async () => {
+        const branches = await api.listBranches({ filter });
+        expect(branches.data.length).toBe(1);
+        expect(branches.data[0].data.id).toBe(branchId);
+        expect(branches.pagination.limit).toBe(limit);
+    });
+
+    it('List directories', async () => {
+        const directories = await api.listDirectories({ filter });
+        expect(directories.data.length).toBe(1);
+        expect(directories.data[0].data.id).toBe(directoryId);
+        expect(directories.pagination.limit).toBe(limit);
+    });
+
+    it('List files', async () => {
+        const files = await api.listFiles({ filter });
+        expect(files.data.length).toBe(1);
+        expect(files.data[0].data.id).toBe(fileId);
+        expect(files.pagination.limit).toBe(limit);
     });
 });

--- a/tests/sourceStrings/api.test.ts
+++ b/tests/sourceStrings/api.test.ts
@@ -19,6 +19,7 @@ describe('Source Strings API', () => {
     const updateOption = 'keep_translations';
 
     const limit = 25;
+    const filter = 'hello';
 
     beforeAll(() => {
         scope = nock(api.url)
@@ -203,6 +204,25 @@ describe('Source Strings API', () => {
                     id: stringId,
                     text: stringText,
                 },
+            })
+            .get('/strings', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ filter })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: stringId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
             });
     });
 
@@ -314,5 +334,12 @@ describe('Source Strings API', () => {
         );
         expect(string.data.id).toBe(stringId);
         expect(string.data.text).toBe(stringText);
+    });
+
+    it('List strings (org-level)', async () => {
+        const strings = await api.listStrings({ filter });
+        expect(strings.data.length).toBe(1);
+        expect(strings.data[0].data.id).toBe(stringId);
+        expect(strings.pagination.limit).toBe(limit);
     });
 });

--- a/tests/translations/api.test.ts
+++ b/tests/translations/api.test.ts
@@ -25,6 +25,8 @@ describe('Translations API', () => {
     const importId = '123';
 
     const limit = 25;
+    const filter = 'hello';
+    const translationId = 999;
 
     beforeAll(() => {
         scope = nock(api.url)
@@ -386,6 +388,25 @@ describe('Translations API', () => {
                     identifier: preTranslationId,
                     attributes: {},
                 },
+            })
+            .get('/translations', undefined, {
+                reqheaders: {
+                    Authorization: `Bearer ${api.token}`,
+                },
+            })
+            .query({ filter })
+            .reply(200, {
+                data: [
+                    {
+                        data: {
+                            id: translationId,
+                        },
+                    },
+                ],
+                pagination: {
+                    offset: 0,
+                    limit: limit,
+                },
             });
     });
 
@@ -565,5 +586,12 @@ describe('Translations API', () => {
         expect(data.languages[0].files[0].id).toBe(fileId);
         expect(data.languages[0].files[0].statistics.phrases).toBe(10);
         expect(data.languages[0].files[0].statistics.words).toBe(25);
+    });
+
+    it('List translations (org-level)', async () => {
+        const translations = await api.listTranslations({ filter });
+        expect(translations.data.length).toBe(1);
+        expect(translations.data[0].data.id).toBe(translationId);
+        expect(translations.pagination.limit).toBe(limit);
     });
 });


### PR DESCRIPTION
…, strings, and translations

Implements issue #706: five enterprise-only endpoints that search across all projects — GET /branches, /directories, /files, /strings, and /translations — each accepting a required filter plus optional projectIds, userId, limit, and offset; strings adds scope/denormalizePlaceholders, translations adds languageIds/denormalizePlaceholders and a new TranslationSearchResult response model.